### PR TITLE
Improve error handling

### DIFF
--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 nose
+mock

--- a/nbsearch/tests/test_source.py
+++ b/nbsearch/tests/test_source.py
@@ -57,3 +57,132 @@ def test_get_files():
         assert files[1]['atime'] < current_time + timedelta(hours=1)
 
         assert source.get_notebook('http://test/server', 'test1/test1sub.ipynb') == {}
+
+def test_get_files_with_nbsearchignore():
+    with tempfile.TemporaryDirectory() as tempdirname:
+        source = LocalSource()
+        source.server = 'http://test/server'
+        source.base_dir = tempdirname
+
+        assert list(source.get_files()) == []
+
+        current_time = datetime.utcnow()
+        time.sleep(3)
+        with open(os.path.join(tempdirname, 'test.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        with open(os.path.join(tempdirname, 'test.dat'), 'w') as f:
+            f.write(json.dumps({}))
+        os.mkdir(os.path.join(tempdirname, 'test1'))
+        with open(os.path.join(tempdirname, 'test1', 'test1sub.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        os.mkdir(os.path.join(tempdirname, 'test2'))
+        with open(os.path.join(tempdirname, 'test2', 'test2sub.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        with open(os.path.join(tempdirname, '.nbsearchignore'), 'w') as f:
+            f.write('''
+# test1/**
+test2/**
+''')
+
+        files = sorted(source.get_files(), key=lambda x: x['path'])
+        assert len(files) == 2
+        assert files[0]['path'] == 'test.ipynb'
+        assert files[0]['mtime'] >= current_time
+        assert files[0]['atime'] >= current_time
+        assert files[0]['mtime'] < current_time + timedelta(hours=1)
+        assert files[0]['atime'] < current_time + timedelta(hours=1)
+        assert files[1]['path'] == 'test1/test1sub.ipynb'
+        assert files[1]['mtime'] >= current_time
+        assert files[1]['atime'] >= current_time
+        assert files[1]['mtime'] < current_time + timedelta(hours=1)
+        assert files[1]['atime'] < current_time + timedelta(hours=1)
+
+        assert source.get_notebook('http://test/server', 'test1/test1sub.ipynb') == {}
+
+def test_get_files_with_nbsearchignore():
+    with tempfile.TemporaryDirectory() as tempdirname:
+        source = LocalSource()
+        source.server = 'http://test/server'
+        source.base_dir = tempdirname
+
+        assert list(source.get_files()) == []
+
+        current_time = datetime.utcnow()
+        time.sleep(3)
+        with open(os.path.join(tempdirname, 'test.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        with open(os.path.join(tempdirname, 'test.dat'), 'w') as f:
+            f.write(json.dumps({}))
+        os.mkdir(os.path.join(tempdirname, 'test1'))
+        with open(os.path.join(tempdirname, 'test1', 'test1sub.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        os.mkdir(os.path.join(tempdirname, 'test2'))
+        with open(os.path.join(tempdirname, 'test2', 'test2sub.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        with open(os.path.join(tempdirname, '.nbsearchignore'), 'w') as f:
+            f.write('''
+# test1/**
+test2/**
+''')
+
+        files = sorted(source.get_files(), key=lambda x: x['path'])
+        assert len(files) == 2
+        assert files[0]['path'] == 'test.ipynb'
+        assert files[0]['mtime'] >= current_time
+        assert files[0]['atime'] >= current_time
+        assert files[0]['mtime'] < current_time + timedelta(hours=1)
+        assert files[0]['atime'] < current_time + timedelta(hours=1)
+        assert files[1]['path'] == 'test1/test1sub.ipynb'
+        assert files[1]['mtime'] >= current_time
+        assert files[1]['atime'] >= current_time
+        assert files[1]['mtime'] < current_time + timedelta(hours=1)
+        assert files[1]['atime'] < current_time + timedelta(hours=1)
+
+        assert source.get_notebook('http://test/server', 'test2/test2sub.ipynb') == {}
+
+def test_get_files_with_nbsearchignores():
+    with tempfile.TemporaryDirectory() as tempdirname:
+        source = LocalSource()
+        source.server = 'http://test/server'
+        source.base_dir = tempdirname
+
+        assert list(source.get_files()) == []
+
+        current_time = datetime.utcnow()
+        time.sleep(3)
+        with open(os.path.join(tempdirname, 'test.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        with open(os.path.join(tempdirname, 'test.dat'), 'w') as f:
+            f.write(json.dumps({}))
+        os.mkdir(os.path.join(tempdirname, 'test1'))
+        with open(os.path.join(tempdirname, 'test1', 'test1sub.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        with open(os.path.join(tempdirname, 'test1', 'ignore.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        os.mkdir(os.path.join(tempdirname, 'test2'))
+        with open(os.path.join(tempdirname, 'test2', 'test2sub.ipynb'), 'w') as f:
+            f.write(json.dumps({}))
+        with open(os.path.join(tempdirname, '.nbsearchignore'), 'w') as f:
+            f.write('''
+# test1/**
+test2/**
+''')
+        with open(os.path.join(tempdirname, 'test1', '.nbsearchignore'), 'w') as f:
+            f.write('''
+ ignore.ipynb
+''')
+
+        files = sorted(source.get_files(), key=lambda x: x['path'])
+        assert len(files) == 2, [f['path'] for f in files]
+        assert files[0]['path'] == 'test.ipynb'
+        assert files[0]['mtime'] >= current_time
+        assert files[0]['atime'] >= current_time
+        assert files[0]['mtime'] < current_time + timedelta(hours=1)
+        assert files[0]['atime'] < current_time + timedelta(hours=1)
+        assert files[1]['path'] == 'test1/test1sub.ipynb'
+        assert files[1]['mtime'] >= current_time
+        assert files[1]['atime'] >= current_time
+        assert files[1]['mtime'] < current_time + timedelta(hours=1)
+        assert files[1]['atime'] < current_time + timedelta(hours=1)
+
+        assert source.get_notebook('http://test/server', 'test1/ignore.ipynb') == {}


### PR DESCRIPTION
ローカルファイルのMongoDBへのインデックス作成において、エラーに関係する処理を改善しました。

* ローカルディレクトリをまとめてMongoDBに反映する際に、一つでもファイルでエラーが発生した際に(長さ0のNotebook - エラーにより保存失敗したケース等)、反映処理全体が中断してしまっていたので、問題があったファイルは最後にまとめて報告するように変更しました。
* MongoDBにインデックスしたくないファイルがあるだろうということで、 `.nbsearchignore` ファイルを導入しました。