### PR TITLE
Add `%%nbsearch` magic commands for searching and inserting notebook cells directly within Jupyter notebooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         pip uninstall -y "nbsearch" jupyterlab
         rm -rf myextension
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-sdist
         path: myextension.tar.gz
@@ -77,7 +77,7 @@ jobs:
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-sdist
     - name: Install and Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,31 @@ jobs:
         name: myextension-sdist
         path: myextension.tar.gz
 
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+        python -m pip install tornado jupyter-server
+
+    - name: Run tests
+      run: |
+        python -m unittest discover nbsearch.tests -v
+
   test_isolated:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -32,14 +32,14 @@ jobs:
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
       - name: Cache pip
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('package.json') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Cache checked links
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pytest-link-check
           key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/.md') }}-md-links
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Upload Distributions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nbsearch-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
 
     - name: Setup pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-3.9-${{ hashFiles('package.json') }}
@@ -35,7 +35,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - name: Setup yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -71,12 +71,12 @@ jobs:
         npm pack
         mv nbsearch-*.tgz myextension-nodejs.tgz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-sdist
         path: myextension.tar.gz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-nodejs
         path: myextension-nodejs.tgz
@@ -88,10 +88,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-sdist
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-nodejs
     - name: release

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ The NBSearch pane allows searching of cells. You can search for preceding and su
 
 The `%%nbsearch` magic command provides a convenient way to search and insert notebook cells directly within your notebook.
 
+![NBSearch Magic Command](./images/magic-command.gif)
+
 #### Simple String Query
 
 ```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ c.LocalSource.server = 'http://localhost:8888/'
 * `c.LocalSource.base_dir` - Notebook directory to be searchable
 * `c.LocalSource.server` - URL of my server, used to identify the notebooks on this server(default: http://localhost:8888/)
 
+### Additional Settings for Magic Commands
+
+To enable the nbsearch magic commands functionality, add the following configuration:
+
+```
+# Enable the JupyterLab extension for nbsearch magic commands
+c.JupyterNotebookApp.expose_app_in_browser = True
+c.LabApp.expose_app_in_browser = True
+```
+
+* `c.JupyterNotebookApp.expose_app_in_browser` - Enables browser exposure for Jupyter Notebook app (required for magic commands)
+* `c.LabApp.expose_app_in_browser` - Enables browser exposure for JupyterLab app (required for magic commands)
+
 ## Usage
 
 ### Add indexes of notebooks to Solr

--- a/README.md
+++ b/README.md
@@ -134,6 +134,49 @@ The NBSearch pane allows searching of cells. You can search for preceding and su
 
 ![NBSearch pane](./images/search-cell.gif)
 
+### Using %%nbsearch Magic Command
+
+The `%%nbsearch` magic command provides a convenient way to search and insert notebook cells directly within your notebook.
+
+#### Simple String Query
+
+```
+%%nbsearch
+ansible hadoop
+```
+
+This executes a full-text search for "ansible hadoop" and opens an interactive search interface where you can browse results and select sections to insert.
+
+#### YAML Query with Multiple Criteria
+
+```
+%%nbsearch
+query:
+  composition: AND
+  keyword:
+    source: "operationhub"
+    outputs: "success"
+```
+
+This searches for notebooks that contain the term "operationhub" .
+
+#### Automatic Updates After Cell Insertion
+
+When you select and insert sections from search results, the magic command automatically updates to include the search metadata:
+
+```
+# %%nbsearch
+# query:
+#   composition: AND
+#   keyword:
+#     source: matplotlib
+#     lc_cell_memes: fc68b4b4-2927-11e9-b46c-0242ac110002
+# sections:
+#   - "# Libraries"
+```
+
+The commented-out lines preserve your search criteria and selected sections. You can uncomment and re-execute to repeat the same search or modify the criteria for new searches. When re-executing, if cells with the same MEME sequence already exist after the current cell, the system will update their content and metadata instead of inserting duplicate cells.
+
 ## Uninstall
 
 To remove the extension, execute:

--- a/example/jupyter_notebook_config.py
+++ b/example/jupyter_notebook_config.py
@@ -2,6 +2,10 @@
 import os
 import tempfile
 
+# Enable the JupyterLab extension for nbsearch magic commands
+c.JupyterNotebookApp.expose_app_in_browser = True
+c.LabApp.expose_app_in_browser = True
+
 def _run_solr_proxy(port):
     conf = tempfile.NamedTemporaryFile(mode='w', delete=False)
     conf.write('''

--- a/nbsearch/magics.py
+++ b/nbsearch/magics.py
@@ -1,0 +1,110 @@
+"""NBSearch IPython Magic Commands"""
+
+from IPython.core.magic import Magics, cell_magic, magics_class
+from IPython.core.display import display, HTML, Javascript
+
+
+@magics_class
+class NBSearchMagics(Magics):
+    """Magic commands for NBSearch functionality"""
+
+    @cell_magic
+    def nbsearch(self, parameter_s, cell):
+        """
+        Cell magic for searching notebook cells using NBSearch extension.
+
+        Usage:
+            %%nbsearch
+            keyword
+
+        Parameters:
+            keyword: The search term to look for in notebook cells
+        """
+        # Parse cell content as YAML or simple keyword
+        import yaml
+        import json
+
+        try:
+            # Try to parse as YAML
+            parsed_query = yaml.safe_load(cell.strip())
+            if isinstance(parsed_query, dict):
+                query_json = json.dumps(parsed_query)
+            else:
+                # If YAML parsing gives a simple string, treat as _text_ query
+                query_json = json.dumps({"_text_": str(parsed_query)})
+        except:
+            # If YAML parsing fails, treat as simple keyword for _text_ search
+            query_json = json.dumps({"_text_": cell.strip()})
+
+        # Generate JavaScript code to trigger extension search widget
+        js_code = f"""
+(function() {{
+    const queryObj = {query_json};
+
+    // Function to create magic search widget via extension command
+    function createMagicSearchWidget() {{
+        const app = window.jupyterapp;
+        if (!app) {{
+            displayError('JupyterLab application not found');
+            return;
+        }}
+
+        // Check if the nbsearch extension command exists
+        if (!app.commands.hasCommand('nbsearch:magic-search')) {{
+            displayError('NBSearch extension not found. Please make sure the nbsearch extension is installed and enabled.');
+            return;
+        }}
+
+        // Execute the extension command with keyword and cell content
+        app.commands.execute('nbsearch:magic-search', {{
+            keyword: queryObj,
+            cellHeader: '%%nbsearch {parameter_s}'.trim(),
+            cellContent: `{cell}`
+        }}).catch(error => {{
+            console.error('Failed to execute nbsearch:magic-search command:', error);
+            displayError(`Failed to create search widget: ${{error.message}}`);
+        }});
+    }}
+
+    // Function to display error message
+    function displayError(message) {{
+        console.error('NBSearch Magic Error:', message);
+
+        // Create a temporary message element as fallback
+        const tempDiv = document.createElement('div');
+        tempDiv.style.cssText = 'position: fixed; top: 20px; right: 20px; z-index: 10000; padding: 16px; border: 2px solid #d32f2f; border-radius: 8px; background: #ffebee; color: #d32f2f; font-weight: bold; max-width: 400px;';
+        tempDiv.innerHTML = `❌ NBSearch Magic Error: ${{message}}`;
+        document.body.appendChild(tempDiv);
+
+        // Auto-remove after 5 seconds
+        setTimeout(() => {{
+            if (tempDiv.parentNode) {{
+                tempDiv.parentNode.removeChild(tempDiv);
+            }}
+        }}, 5000);
+    }}
+
+    // Main execution
+    try {{
+        createMagicSearchWidget();
+    }} catch (error) {{
+        console.error('NBSearch Magic Error:', error);
+        displayError(`Failed to create search interface: ${{error.message}}`);
+    }}
+}})();
+"""
+
+        # Execute the JavaScript code
+        display(Javascript(js_code))
+
+
+def load_ipython_extension(ipython):
+    """Load the NBSearch magic extension"""
+    magics = NBSearchMagics(ipython)
+    ipython.register_magic_function(magics.nbsearch, 'cell')
+
+
+def unload_ipython_extension(ipython):
+    """Unload the NBSearch magic extension"""
+    # Magic commands are automatically unloaded when the extension is unloaded
+    pass

--- a/nbsearch/magics.py
+++ b/nbsearch/magics.py
@@ -1,7 +1,7 @@
 """NBSearch IPython Magic Commands"""
 
 from IPython.core.magic import Magics, cell_magic, magics_class
-from IPython.core.display import display, HTML, Javascript
+from IPython.core.display import HTML, Javascript
 
 
 @magics_class
@@ -95,7 +95,7 @@ class NBSearchMagics(Magics):
 """
 
         # Execute the JavaScript code
-        display(Javascript(js_code))
+        return Javascript(js_code)
 
 
 def load_ipython_extension(ipython):

--- a/nbsearch/server.py
+++ b/nbsearch/server.py
@@ -9,6 +9,7 @@ from .v1.handlers import (
     NBSEARCH_TMP,
     SearchHandler,
     ImportHandler,
+    DataHandler,
 )
 
 
@@ -35,6 +36,7 @@ def get_api_handlers(parent_app, base_dir):
     return [
         (r"/v1/(?P<target>[^\/]+)/search", SearchHandler, handler_settings),
         (r"/v1/import(?P<path>/.+)?/(?P<id>[^\/]+)", ImportHandler, handler_settings),
+        (r"/v1/data/(?P<id>[^\/]+)", DataHandler, handler_settings),
     ]
 
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
         "@lumino/signaling": "^2.1.2",
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.0",
-        "codemirror": "^5.65.16"
+        "codemirror": "^5.65.16",
+        "yaml": "^2.8.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/src/components/dialog/section-selection.tsx
+++ b/src/components/dialog/section-selection.tsx
@@ -142,13 +142,16 @@ export async function showSectionSelectionDialog(
 ): Promise<NotebookSection[] | null> {
   // Convert initial section titles to indices
   // If no initial selection is provided or it's empty, select all sections
-  const initialSelectedIndices = initialSelectedSectionTitles && initialSelectedSectionTitles.length > 0
-    ? new Set(
-        initialSelectedSectionTitles
-          .map(title => sections.findIndex(section => section.title === title))
-          .filter(index => index !== -1)
-      )
-    : new Set(sections.map((_, index) => index)); // Select all sections by default
+  const initialSelectedIndices =
+    initialSelectedSectionTitles && initialSelectedSectionTitles.length > 0
+      ? new Set(
+          initialSelectedSectionTitles
+            .map(title =>
+              sections.findIndex(section => section.title === title)
+            )
+            .filter(index => index !== -1)
+        )
+      : new Set(sections.map((_, index) => index)); // Select all sections by default
 
   const widget = new SectionSelectionWidget(sections, initialSelectedIndices);
 

--- a/src/components/dialog/section-selection.tsx
+++ b/src/components/dialog/section-selection.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from 'react';
+import { Dialog, ReactWidget, showDialog } from '@jupyterlab/apputils';
+import {
+  Box,
+  FormControlLabel,
+  Checkbox,
+  Typography,
+  Button,
+  Stack
+} from '@mui/material';
+
+export type NotebookSection = {
+  title: string;
+  startIndex: number;
+  endIndex: number;
+  cells: any[];
+};
+
+interface ISectionSelectionWidgetProps {
+  sections: NotebookSection[];
+  onSelectionChange: (selectedSections: NotebookSection[]) => void;
+  initialSelectedIndices?: Set<number>;
+}
+
+function SectionSelectionComponent({
+  sections,
+  onSelectionChange,
+  initialSelectedIndices
+}: ISectionSelectionWidgetProps): JSX.Element {
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(
+    initialSelectedIndices || new Set()
+  );
+
+  const handleCheckboxChange = (index: number, checked: boolean) => {
+    const newSelectedIndices = new Set(selectedIndices);
+    if (checked) {
+      newSelectedIndices.add(index);
+    } else {
+      newSelectedIndices.delete(index);
+    }
+    setSelectedIndices(newSelectedIndices);
+
+    const selected = Array.from(newSelectedIndices).map(i => sections[i]);
+    onSelectionChange(selected);
+  };
+
+  const handleSelectAll = () => {
+    const allIndices = new Set(sections.map((_, index) => index));
+    setSelectedIndices(allIndices);
+    onSelectionChange(sections);
+  };
+
+  const handleDeselectAll = () => {
+    setSelectedIndices(new Set());
+    onSelectionChange([]);
+  };
+
+  return (
+    <Box sx={{ minWidth: 400 }}>
+      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+        <Button size="small" variant="outlined" onClick={handleSelectAll}>
+          Select All
+        </Button>
+        <Button size="small" variant="outlined" onClick={handleDeselectAll}>
+          Deselect All
+        </Button>
+      </Stack>
+      <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
+        {sections.map((section, index) => (
+          <Box
+            key={index}
+            sx={{
+              margin: '10px 0',
+              padding: '10px',
+              border: '1px solid #ddd',
+              borderRadius: '4px'
+            }}
+          >
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={selectedIndices.has(index)}
+                  onChange={e => handleCheckboxChange(index, e.target.checked)}
+                />
+              }
+              label={
+                <Box>
+                  <Typography variant="subtitle1" component="div">
+                    <strong>{section.title}</strong>
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {section.cells.length} cells
+                  </Typography>
+                </Box>
+              }
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+class SectionSelectionWidget extends ReactWidget {
+  private sections: NotebookSection[];
+  private selectedSections: NotebookSection[] = [];
+  private initialSelectedIndices?: Set<number>;
+
+  constructor(
+    sections: NotebookSection[],
+    initialSelectedIndices?: Set<number>
+  ) {
+    super();
+    this.addClass('section-selection-widget');
+    this.sections = sections;
+    this.initialSelectedIndices = initialSelectedIndices;
+    this.selectedSections = initialSelectedIndices
+      ? Array.from(initialSelectedIndices).map(index => sections[index])
+      : sections; // Select all sections by default
+  }
+
+  render(): JSX.Element {
+    const handleSelectionChange = (selectedSections: NotebookSection[]) => {
+      this.selectedSections = selectedSections;
+    };
+    return (
+      <SectionSelectionComponent
+        sections={this.sections}
+        onSelectionChange={handleSelectionChange}
+        initialSelectedIndices={this.initialSelectedIndices}
+      />
+    );
+  }
+  getSelectedSections(): NotebookSection[] {
+    return this.selectedSections;
+  }
+}
+
+export async function showSectionSelectionDialog(
+  sections: NotebookSection[],
+  initialSelectedSectionTitles?: string[]
+): Promise<NotebookSection[] | null> {
+  // Convert initial section titles to indices
+  // If no initial selection is provided or it's empty, select all sections
+  const initialSelectedIndices = initialSelectedSectionTitles && initialSelectedSectionTitles.length > 0
+    ? new Set(
+        initialSelectedSectionTitles
+          .map(title => sections.findIndex(section => section.title === title))
+          .filter(index => index !== -1)
+      )
+    : new Set(sections.map((_, index) => index)); // Select all sections by default
+
+  const widget = new SectionSelectionWidget(sections, initialSelectedIndices);
+
+  const result = await showDialog({
+    title: 'Select Sections to Add',
+    body: widget,
+    buttons: [
+      Dialog.cancelButton({ label: 'Cancel' }),
+      Dialog.okButton({ label: 'Add Selected Sections' })
+    ]
+  });
+  const selectedSections = widget.getSelectedSections();
+  widget.dispose();
+  if (result.button.accept) {
+    return selectedSections.length > 0 ? selectedSections : null;
+  }
+  return null;
+}

--- a/src/components/query/cell.tsx
+++ b/src/components/query/cell.tsx
@@ -168,12 +168,14 @@ export type QueryProps = {
   targetCell: Cell;
   location: CellLocation;
   onChange?: (query: LazySolrQuery, compositeQuery?: CompositeQuery) => void;
+  onSearch?: () => void;
   fields?: IndexedColumnId[];
   initialFieldsValue?: CompositeQuery;
 };
 
 export function Query({
   onChange,
+  onSearch,
   targetCell,
   location,
   fields,
@@ -285,6 +287,7 @@ export function Query({
         <FieldsQuery
           fields={fields}
           onChange={fieldsChanged}
+          onSearch={onSearch}
           initialValue={initialFieldsValue}
         />
       </TabPanel>

--- a/src/components/query/fields.tsx
+++ b/src/components/query/fields.tsx
@@ -166,12 +166,14 @@ export type CompositeQuery = {
 
 export type FieldsQueryProps = {
   onChange?: (query: SolrQuery, compositeQuery: CompositeQuery) => void;
+  onSearch?: () => void;
   fields?: IndexedColumnId[];
   initialValue?: CompositeQuery;
 };
 
 export function FieldsQuery({
   onChange,
+  onSearch,
   fields: customFields,
   initialValue
 }: FieldsQueryProps): JSX.Element {
@@ -322,7 +324,16 @@ export function FieldsQuery({
         {fieldQueries.map((query, index) => {
           const field = FIELDS.find(field => field.id === query.target);
           return (
-            <Box key={index} className="nbsearch-query-fields-value">
+            <Box
+              key={index}
+              className="nbsearch-query-fields-value"
+              sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 1,
+                mb: 2
+              }}
+            >
               <TextField
                 label={field?.label}
                 helperText={
@@ -331,13 +342,20 @@ export function FieldsQuery({
                     : 'Solr Query: e.g. *'
                 }
                 defaultValue={query.query}
+                fullWidth
                 onChange={(
                   event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
                 ) => updateFieldQueriesQuery(index, event.target.value)}
+                onKeyDown={event => {
+                  if (event.key === 'Enter' && onSearch) {
+                    onSearch();
+                  }
+                }}
               />
               <Button
                 onClick={() => deleteFieldQueries(index)}
                 disabled={fieldQueries.length <= 1}
+                sx={{ minWidth: 'auto', mt: 1 }}
               >
                 <DeleteIcon />
               </Button>
@@ -346,7 +364,15 @@ export function FieldsQuery({
         })}
       </Box>
       {defaultField !== undefined && (
-        <Box className="nbsearch-query-fields-add">
+        <Box
+          className="nbsearch-query-fields-add"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            mt: 1
+          }}
+        >
           <Button onClick={() => addFieldQueries()}>
             <AddIcon />
           </Button>

--- a/src/components/query/fields.tsx
+++ b/src/components/query/fields.tsx
@@ -165,22 +165,28 @@ export type CompositeQuery = {
 };
 
 export type FieldsQueryProps = {
-  onChange?: (query: SolrQuery) => void;
+  onChange?: (query: SolrQuery, compositeQuery: CompositeQuery) => void;
   fields?: IndexedColumnId[];
+  initialValue?: CompositeQuery;
 };
 
 export function FieldsQuery({
   onChange,
-  fields: customFields
+  fields: customFields,
+  initialValue
 }: FieldsQueryProps): JSX.Element {
-  const [composition, setComposition] = useState<Composition>(Composition.And);
+  const [composition, setComposition] = useState<Composition>(
+    initialValue?.composition ?? Composition.And
+  );
   const [selectedField, setSelectedField] = useState<Field | null>(null);
-  const [fieldQueries, setFieldQueries] = useState<FieldQuery[]>([
-    {
-      target: IndexedColumnId.FullText,
-      query: '*'
-    }
-  ]);
+  const [fieldQueries, setFieldQueries] = useState<FieldQuery[]>(
+    initialValue?.fields ?? [
+      {
+        target: IndexedColumnId.FullText,
+        query: '*'
+      }
+    ]
+  );
 
   const fields = useMemo(() => {
     const splittedCustomFields = customFields
@@ -221,12 +227,19 @@ export function FieldsQuery({
       const solrQuery = newQueries
         .map(field => `${field.target}:${field.query}`)
         .join(` ${composition} `);
+      const compositeQuery: CompositeQuery = {
+        composition,
+        fields: newQueries
+      };
       if (!onChange) {
         return;
       }
-      onChange({
-        queryString: solrQuery
-      });
+      onChange(
+        {
+          queryString: solrQuery
+        },
+        compositeQuery
+      );
     },
     [onChange]
   );

--- a/src/components/query/notebook.tsx
+++ b/src/components/query/notebook.tsx
@@ -13,6 +13,7 @@ enum TabIndex {
 
 export type QueryProps = {
   onChange?: (query: SolrQuery, compositeQuery?: CompositeQuery) => void;
+  onSearch?: () => void;
   fields?: IndexedColumnId[];
   initialFieldsValue?: CompositeQuery;
 };
@@ -39,6 +40,7 @@ function TabPanel(props: TabPanelProps): JSX.Element {
 
 export function Query({
   onChange,
+  onSearch,
   fields,
   initialFieldsValue
 }: QueryProps): JSX.Element {
@@ -109,6 +111,7 @@ export function Query({
         <FieldsQuery
           fields={fields}
           onChange={fieldsChanged}
+          onSearch={onSearch}
           initialValue={initialFieldsValue}
         />
       </TabPanel>

--- a/src/components/query/notebook.tsx
+++ b/src/components/query/notebook.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { Box, Tabs, Tab } from '@mui/material';
 
-import { FieldsQuery } from './fields';
+import { FieldsQuery, CompositeQuery } from './fields';
 import { SolrQuery } from './base';
 import { RawSolrQuery } from './solr';
 import { IndexedColumnId } from '../result/result';
@@ -12,8 +12,9 @@ enum TabIndex {
 }
 
 export type QueryProps = {
-  onChange?: (query: SolrQuery) => void;
+  onChange?: (query: SolrQuery, compositeQuery?: CompositeQuery) => void;
   fields?: IndexedColumnId[];
+  initialFieldsValue?: CompositeQuery;
 };
 
 type TabPanelProps = {
@@ -36,13 +37,20 @@ function TabPanel(props: TabPanelProps): JSX.Element {
   );
 }
 
-export function Query({ onChange, fields }: QueryProps): JSX.Element {
+export function Query({
+  onChange,
+  fields,
+  initialFieldsValue
+}: QueryProps): JSX.Element {
   const [solrQuery, setSolrQuery] = useState<SolrQuery>({
     queryString: '_text_:*'
   });
   const [fieldsQuery, setFieldsQuery] = useState<SolrQuery>({
     queryString: '_text_:*'
   });
+  const [fieldsCompositeQuery, setFieldsCompositeQuery] = useState<
+    CompositeQuery | undefined
+  >(undefined);
   const [tabIndex, setTabIndex] = useState<TabIndex>(TabIndex.Fields);
 
   const solrChanged = useCallback(
@@ -56,12 +64,13 @@ export function Query({ onChange, fields }: QueryProps): JSX.Element {
     [onChange]
   );
   const fieldsChanged = useCallback(
-    (query: SolrQuery) => {
+    (query: SolrQuery, compositeQuery: CompositeQuery) => {
       setFieldsQuery(query);
+      setFieldsCompositeQuery(compositeQuery);
       if (!onChange) {
         return;
       }
-      onChange(query);
+      onChange(query, compositeQuery);
     },
     [onChange]
   );
@@ -72,7 +81,10 @@ export function Query({ onChange, fields }: QueryProps): JSX.Element {
       if (!onChange) {
         return;
       }
-      onChange(index === TabIndex.Fields ? fieldsQuery : solrQuery);
+      onChange(
+        index === TabIndex.Fields ? fieldsQuery : solrQuery,
+        index === TabIndex.Fields ? fieldsCompositeQuery : undefined
+      );
     },
     [fieldsQuery, solrQuery, onChange]
   );
@@ -94,7 +106,11 @@ export function Query({ onChange, fields }: QueryProps): JSX.Element {
         />
       </Tabs>
       <TabPanel id={TabIndex.Fields} value={tabIndex}>
-        <FieldsQuery fields={fields} onChange={fieldsChanged} />
+        <FieldsQuery
+          fields={fields}
+          onChange={fieldsChanged}
+          initialValue={initialFieldsValue}
+        />
       </TabPanel>
       <TabPanel id={TabIndex.Solr} value={tabIndex}>
         <RawSolrQuery onChange={solrChanged} query={solrQuery.queryString} />

--- a/src/components/result/result.tsx
+++ b/src/components/result/result.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { TableRow, TableCell, Link } from '@mui/material';
+import { TableRow, TableCell, Link, Button } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 
 export enum IndexedColumnId {
   FullText = '_text_',
@@ -71,6 +72,8 @@ export type ResultProps = {
   columns: (StoredColumnId | StoredColumnId[])[];
   data: ResultEntity;
   onSelect?: (result: ResultEntity) => void;
+  onAdd?: (result: ResultEntity) => void;
+  showAddButton?: boolean;
   maxLength?: number;
 };
 
@@ -122,12 +125,31 @@ function renderValue(
   return <div>{value}</div>;
 }
 
-export function Result({ columns, data, onSelect, maxLength }: ResultProps) {
+export function Result({
+  columns,
+  data,
+  onSelect,
+  onAdd,
+  showAddButton,
+  maxLength
+}: ResultProps) {
   return (
     <TableRow>
       {columns.map(column => (
         <TableCell>{renderValue(data, column, onSelect, maxLength)}</TableCell>
       ))}
+      {showAddButton && (
+        <TableCell>
+          <Button
+            size="small"
+            onClick={() => onAdd?.(data)}
+            startIcon={<AddIcon />}
+            variant="outlined"
+          >
+            Add
+          </Button>
+        </TableCell>
+      )}
     </TableRow>
   );
 }

--- a/src/components/result/results.tsx
+++ b/src/components/result/results.tsx
@@ -39,6 +39,8 @@ export type ResultsProps = {
   columns: ResultColumn[];
   onColumnSort?: (key: SortQuery) => void;
   onResultSelect?: (data: ResultEntity) => void;
+  onResultAdd?: (data: ResultEntity) => void;
+  showAddButton?: boolean;
   maxLength?: number;
 };
 
@@ -83,6 +85,8 @@ export function Results({
   data,
   onColumnSort,
   onResultSelect,
+  onResultAdd,
+  showAddButton,
   maxLength
 }: ResultsProps) {
   if (!data || data.length === 0) {
@@ -108,12 +112,15 @@ export function Results({
           {columns.map(column => (
             <TableCell>{renderColumn(column, sorted, sortQuery)}</TableCell>
           ))}
+          {showAddButton && <TableCell>Action</TableCell>}
         </TableRow>
       </TableHead>
       <TableBody>
         {data.map(result => (
           <Result
             onSelect={onResultSelect}
+            onAdd={onResultAdd}
+            showAddButton={showAddButton}
             columns={columns.map(c => c.value)}
             data={result}
             maxLength={maxLength}

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -25,6 +25,8 @@ export type SearchProps = {
   columns: ResultColumn[];
   onSearch?: (query: SearchQuery, finished: () => void) => void;
   onResultSelect?: (result: ResultEntity) => void;
+  onResultAdd?: (result: ResultEntity) => void;
+  showAddButton?: boolean;
   defaultQuery: SolrQuery;
   queryFactory: (
     onChange: (query: LazySolrQuery) => void
@@ -36,12 +38,15 @@ export type SearchProps = {
   numFound?: number;
   results?: ResultEntity[];
   error?: SearchError;
+  onClosed?: () => void;
 };
 
 export function Search({
   columns,
   onSearch,
   onResultSelect,
+  onResultAdd,
+  showAddButton,
   start,
   limit,
   numFound,
@@ -50,7 +55,8 @@ export function Search({
   readyToSearch,
   defaultQuery,
   queryFactory,
-  queryContext
+  queryContext,
+  onClosed
 }: SearchProps): JSX.Element {
   const [solrQuery, setSolrQuery] = useState<LazySolrQuery | null>(null);
   const [sortQuery, setSortQuery] = useState<SortQuery | null>(null);
@@ -119,6 +125,11 @@ export function Search({
         >
           {!searching ? 'Search' : 'Searching...'}
         </Button>
+        {onClosed && (
+          <Button variant="outlined" onClick={onClosed} sx={{ ml: 1 }}>
+            Close
+          </Button>
+        )}
       </Box>
       <Page
         start={start}
@@ -131,6 +142,8 @@ export function Search({
             columns={columns}
             onColumnSort={sorted}
             onResultSelect={onResultSelect}
+            onResultAdd={onResultAdd}
+            showAddButton={showAddButton}
             data={results}
             maxLength={COLUMN_MAX_LENGTH}
           />

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { Box, Button, TableContainer } from '@mui/material';
 
 import { ResultEntity } from './result/result';
@@ -34,6 +34,7 @@ export type SearchProps = {
   ) => React.ReactNode | null;
   queryContext: SolrQueryContext;
   readyToSearch?: boolean;
+  autoSearch?: boolean;
   start?: number;
   limit?: number;
   numFound?: number;
@@ -54,6 +55,7 @@ export function Search({
   results,
   error,
   readyToSearch,
+  autoSearch,
   defaultQuery,
   queryFactory,
   queryContext,
@@ -63,6 +65,7 @@ export function Search({
   const [sortQuery, setSortQuery] = useState<SortQuery | null>(null);
   const [pageQuery, setPageQuery] = useState<PageQuery | null>(null);
   const [searching, setSearching] = useState<boolean>(false);
+  const [hasAutoSearched, setHasAutoSearched] = useState<boolean>(false);
   const searchQuery = useMemo(() => {
     const r: SearchQuery = Object.assign(
       {},
@@ -95,6 +98,14 @@ export function Search({
   const clicked = useCallback(() => {
     callSearch(searchQuery);
   }, [callSearch, searchQuery]);
+
+  // Auto-search on first render if autoSearch is enabled
+  useEffect(() => {
+    if (autoSearch && !hasAutoSearched && onSearch) {
+      setHasAutoSearched(true);
+      callSearch(searchQuery);
+    }
+  }, [autoSearch, hasAutoSearched, onSearch, callSearch, searchQuery]);
   const sorted = useCallback(
     (sortQuery: SortQuery) => {
       setSortQuery(sortQuery);

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -29,7 +29,8 @@ export type SearchProps = {
   showAddButton?: boolean;
   defaultQuery: SolrQuery;
   queryFactory: (
-    onChange: (query: LazySolrQuery) => void
+    onChange: (query: LazySolrQuery) => void,
+    onSearch?: () => void
   ) => React.ReactNode | null;
   queryContext: SolrQueryContext;
   readyToSearch?: boolean;
@@ -113,7 +114,7 @@ export function Search({
 
   return (
     <Box sx={{ padding: '1em' }}>
-      {queryFactory(solrQueryChanged)}
+      {queryFactory(solrQueryChanged, clicked)}
       <Box className="nbsearch-search-execute">
         {error && (
           <strong className="nbsearch-search-error">{error.message}</strong>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { INotebookTracker } from '@jupyterlab/notebook';
+import { CodeCell } from '@jupyterlab/cells';
 
 import { buildTreeWidget } from './widgets/tree-search';
 import { buildCellWidget } from './widgets/cell-search';
@@ -13,6 +14,39 @@ import { Platform, PlatformType, getPlatform } from './widgets/platform';
 import { ToolbarExtension } from './extensions/toolbar';
 import { CellExtension } from './extensions/cell';
 import { NotebookManager } from './extensions/cellmanager';
+import { createMagicSearchWidget } from './widgets/magic-search';
+
+/**
+ * Find the CodeCell that contains the magic command by cell content
+ */
+function findCodeCellByCellContent(
+  cellHeader: string,
+  cellContent: string,
+  notebookTracker: INotebookTracker
+): CodeCell | undefined {
+  if (!cellContent || !notebookTracker.currentWidget) {
+    return undefined;
+  }
+  const notebookPanel = notebookTracker.currentWidget;
+  if (!notebookPanel) {
+    return undefined;
+  }
+  const notebook = notebookPanel.content;
+  for (let i = 0; i < notebook.widgets.length; i++) {
+    const cellWidget = notebook.widgets[i];
+    if (cellWidget instanceof CodeCell) {
+      const codeCell = cellWidget as CodeCell;
+      const source = codeCell.model.sharedModel.getSource();
+      const wholeCellContent = cellHeader + '\n' + cellContent;
+      // Check if this cell contains the exact content
+      if (source.trim() === wholeCellContent.trim()) {
+        return codeCell;
+      }
+    }
+  }
+
+  return undefined;
+}
 
 async function initialize(
   app: JupyterFrontEnd,
@@ -73,6 +107,42 @@ const plugin: JupyterFrontEndPlugin<void> = {
       'Notebook',
       new CellExtension(notebookTracker, notebookManager)
     );
+
+    // Add command for magic-triggered search
+    app.commands.addCommand('nbsearch:magic-search', {
+      label: 'NBSearch Magic Search',
+      execute: (args: any) => {
+        const { keyword, cellHeader, cellContent } = args;
+        console.log(
+          'Executing NBSearch magic search with keyword:',
+          keyword,
+          'cellHeader:',
+          cellHeader,
+          'cellContent:',
+          cellContent
+        );
+
+        // Find the CodeCell that contains the magic command by cell content
+        const codeCell = findCodeCellByCellContent(
+          cellHeader,
+          cellContent,
+          notebookTracker
+        );
+        if (!codeCell) {
+          console.error('No CodeCell found for the given cell content.');
+          return;
+        }
+
+        createMagicSearchWidget(
+          documents,
+          notebookTracker,
+          notebookManager,
+          keyword,
+          codeCell
+        );
+      }
+    });
+
     initialize(app, settingRegistry, plugin.id)
       .then(({ platform, settings }) => {
         initWidgets(

--- a/src/widgets/cell-search.tsx
+++ b/src/widgets/cell-search.tsx
@@ -106,7 +106,7 @@ export function SearchWidget({
     );
   }, [currentNotebookPanel, currentCell, notebookManager]);
   const queryFactory = useCallback(
-    (onChange: (query: LazySolrQuery) => void) => {
+    (onChange: (query: LazySolrQuery) => void, onSearch?: () => void) => {
       if (!currentCell) {
         return null;
       }
@@ -115,6 +115,7 @@ export function SearchWidget({
           targetCell={currentCell}
           location={currentCellLocation}
           onChange={onChange}
+          onSearch={onSearch}
           fields={searchFields}
         ></Query>
       );

--- a/src/widgets/icons.tsx
+++ b/src/widgets/icons.tsx
@@ -15,7 +15,9 @@ function extractSvgString(icon: Icon): string {
 </svg>`;
 }
 
+export const nbsearchIcon = extractSvgString(faMagnifyingGlass);
+
 export const searchIcon = new LabIcon({
   name: 'nbsearch::notebooksearch',
-  svgstr: extractSvgString(faMagnifyingGlass)
+  svgstr: nbsearchIcon
 });

--- a/src/widgets/magic-search.tsx
+++ b/src/widgets/magic-search.tsx
@@ -4,6 +4,7 @@ import { ReactWidget } from '@jupyterlab/apputils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { CodeCell } from '@jupyterlab/cells';
+import { ISharedMarkdownCell, ISharedRawCell } from '@jupyter/ydoc';
 
 import { Box, ThemeProvider } from '@mui/material';
 
@@ -66,6 +67,17 @@ function getOutputElementFromCodeCell(codeCell: CodeCell): HTMLElement {
     return outputElement;
   }
   throw new Error('No output area found in the provided CodeCell');
+}
+
+/**
+ * Arrange metadata for a notebook cell.
+ */
+function arrangeMetadata(metadata: any): any {
+  const newMetadata = { ...metadata };
+  newMetadata.deletable = true;
+  newMetadata.editable = true;
+  newMetadata.trusted = true;
+  return newMetadata;
 }
 
 type Keyword = {
@@ -185,6 +197,11 @@ function parseNotebookSections(cells: any[]): NotebookSection[] {
   return sections;
 }
 
+type InsertedContent = {
+  insertedMEMEs?: string[];
+  selectedSectionTitles?: string[];
+};
+
 type MagicSearchWidgetProps = {
   currentCell: CodeCell;
   documents: IDocumentManager;
@@ -195,7 +212,7 @@ type MagicSearchWidgetProps = {
   onClosed?: (
     inserted: boolean,
     latestCompositeQuery?: CompositeQuery,
-    selectedSectionTitles?: string[]
+    insertedContent?: InsertedContent
   ) => void;
 };
 const resultColumns: ResultColumn[] = [
@@ -295,79 +312,158 @@ export function MagicSearchWidget({
         console.warn('No notebook_id found in result');
         return;
       }
-      try {
-        const notebookData = await requestAPI<any>(`v1/data/${result.id}`);
-        console.log('DataHandler response:', notebookData);
+      const notebookData = await requestAPI<any>(`v1/data/${result.id}`);
 
-        // Get the current notebook and find the current cell's index
-        const currentNotebook = notebookTracker.currentWidget?.model;
-        if (!currentNotebook || !notebookData.notebook?.cells) {
-          console.warn('No current notebook or cells data');
-          return;
+      const currentNotebook = notebookTracker.currentWidget?.model;
+      if (!currentNotebook || !notebookData.notebook?.cells) {
+        console.warn('No current notebook or cells data');
+        return;
+      }
+
+      const sections = parseNotebookSections(notebookData.notebook.cells);
+
+      // Show section selection dialog
+      const selectedSections = await showSectionSelectionDialog(
+        sections,
+        lastSelectedSections
+      );
+
+      if (!selectedSections || selectedSections.length === 0) {
+        console.log('Cell insertion cancelled by user or no sections selected');
+        return;
+      }
+
+      const currentCellIndex = [...currentNotebook.cells].findIndex(
+        cell => cell.id === currentCell.model.id
+      );
+
+      if (currentCellIndex === -1) {
+        console.warn('Current cell not found in notebook');
+        return;
+      }
+
+      // Get MEME sequence from selected sections
+      const selectedMEMEs: string[] = [];
+      for (const section of selectedSections) {
+        for (const cellData of section.cells) {
+          if (cellData.metadata?.lc_cell_meme?.current) {
+            selectedMEMEs.push(cellData.metadata.lc_cell_meme.current);
+          }
         }
+      }
 
-        // Parse notebook into sections
-        const sections = parseNotebookSections(notebookData.notebook.cells);
-
-        // Show section selection dialog
-        const selectedSections = await showSectionSelectionDialog(
-          sections,
-          lastSelectedSections
-        );
-
-        if (!selectedSections || selectedSections.length === 0) {
-          console.log(
-            'Cell insertion cancelled by user or no sections selected'
-          );
-          return;
+      // Get MEME sequence from current notebook starting after currentCell
+      const existingMEMEs: string[] = [];
+      for (
+        let i = currentCellIndex + 1;
+        i < currentNotebook.cells.length;
+        i++
+      ) {
+        const cell = currentNotebook.cells.get(i);
+        const meme = (cell.metadata?.lc_cell_meme as any)?.current;
+        if (meme && typeof meme === 'string') {
+          existingMEMEs.push(meme);
         }
+      }
 
-        // Find the index of the current cell
-        const currentCellIndex = [...currentNotebook.cells].findIndex(
-          cell => cell.id === currentCell.model.id
-        );
+      // Check if MEME sequences match
+      const sequencesMatch =
+        selectedMEMEs.length === existingMEMEs.length &&
+        selectedMEMEs.every((meme, index) => meme === existingMEMEs[index]);
 
-        if (currentCellIndex === -1) {
-          console.warn('Current cell not found in notebook');
-          return;
-        }
+      let insertIndex = currentCellIndex + 1;
+      let totalInsertedCells = 0;
+      let totalUpdatedCells = 0;
+      const insertedMEMEs: string[] = [];
 
-        // selectedSections is already validated above
-
-        // Insert cells from selected sections after the current cell
-        let insertIndex = currentCellIndex + 1;
-        let totalInsertedCells = 0;
-
+      if (sequencesMatch) {
+        // Update existing cells instead of inserting new ones
+        let cellIndex = currentCellIndex + 1;
         for (const section of selectedSections) {
           for (const cellData of section.cells) {
-            const newCell = {
+            if (cellIndex < currentNotebook.cells.length) {
+              const existingCell = currentNotebook.cells.get(cellIndex);
+              // Update cell content and metadata
+              const sourceContent = Array.isArray(cellData.source)
+                ? cellData.source.join('\n')
+                : cellData.source;
+              existingCell.sharedModel.setSource(sourceContent);
+              existingCell.sharedModel.setMetadata(
+                arrangeMetadata(cellData.metadata || {})
+              );
+              if (cellData.attachments) {
+                // Only markdown and raw cells support attachments
+                if (
+                  cellData.cell_type === 'markdown' ||
+                  cellData.cell_type === 'raw'
+                ) {
+                  (
+                    existingCell.sharedModel as
+                      | ISharedMarkdownCell
+                      | ISharedRawCell
+                  ).setAttachments(cellData.attachments);
+                }
+              }
+              totalUpdatedCells++;
+              cellIndex++;
+
+              if (cellData.metadata?.lc_cell_meme?.current) {
+                insertedMEMEs.push(cellData.metadata.lc_cell_meme.current);
+              }
+            }
+          }
+        }
+      } else {
+        // Insert new cells as before
+        for (const section of selectedSections) {
+          for (const cellData of section.cells) {
+            const newCell: any = {
               cell_type: cellData.cell_type,
               source: cellData.source,
-              metadata: cellData.metadata || {},
+              metadata: arrangeMetadata(cellData.metadata || {}),
               trusted: true
             };
+            if (
+              cellData.attachments &&
+              (cellData.cell_type === 'markdown' ||
+                cellData.cell_type === 'raw')
+            ) {
+              newCell.attachments = cellData.attachments;
+            }
             currentNotebook.sharedModel.insertCell(insertIndex, newCell);
             insertIndex++;
             totalInsertedCells++;
+            if (cellData.metadata?.lc_cell_meme?.current) {
+              insertedMEMEs.push(cellData.metadata.lc_cell_meme.current);
+            }
           }
         }
+      }
 
+      if (sequencesMatch) {
+        console.log(
+          `Updated ${totalUpdatedCells} existing cells from ${selectedSections.length} sections`,
+          'Latest composite query:',
+          latestCompositeQuery
+        );
+      } else {
         console.log(
           `Inserted ${totalInsertedCells} cells from ${selectedSections.length} sections after current cell`,
           'Latest composite query:',
           latestCompositeQuery
         );
+      }
 
-        // Close the search display
-        setIsClosed(true);
-        if (onClosed) {
-          const selectedSectionTitles = selectedSections.map(
-            section => section.title
-          );
-          onClosed(true, latestCompositeQuery, selectedSectionTitles);
-        }
-      } catch (error) {
-        console.error('Error calling DataHandler:', error);
+      // Close the search display
+      setIsClosed(true);
+      if (onClosed) {
+        const selectedSectionTitles = selectedSections.map(
+          section => section.title
+        );
+        onClosed(true, latestCompositeQuery, {
+          insertedMEMEs,
+          selectedSectionTitles
+        });
       }
     },
     [notebookTracker, currentCell, latestCompositeQuery, onClosed, documents]
@@ -440,7 +536,10 @@ export function MagicSearchWidget({
           error={error}
           onClosed={
             onClosed
-              ? () => onClosed(false, latestCompositeQuery, [])
+              ? () =>
+                  onClosed(false, latestCompositeQuery, {
+                    selectedSectionTitles: []
+                  })
               : undefined
           }
         />
@@ -493,18 +592,22 @@ export function createMagicSearchWidget(
           onClosed={(
             inserted: boolean,
             latestCompositeQuery?: CompositeQuery,
-            selectedSectionTitles?: string[]
+            insertedContent?: InsertedContent
           ) => {
             // Use the latest composite query if available, otherwise fall back to original keyword
             const keywordToUse = latestCompositeQuery
               ? getKeywordFromCompositeQuery(latestCompositeQuery)
               : keyword || {};
+            if (insertedContent?.insertedMEMEs) {
+              keywordToUse.keyword.lc_cell_memes =
+                insertedContent.insertedMEMEs[0];
+            }
 
             // Convert keyword to YAML and set as cell source
             let yamlLines: string[] = ['%%nbsearch'];
             const yamlData: KeywordWithSections = {
               query: keywordToUse,
-              sections: selectedSectionTitles || []
+              sections: insertedContent?.selectedSectionTitles || []
             };
             yamlLines = yamlLines.concat(
               stringify(yamlData).trim().split('\n')

--- a/src/widgets/magic-search.tsx
+++ b/src/widgets/magic-search.tsx
@@ -1,0 +1,606 @@
+import React, { useCallback, useState } from 'react';
+import { stringify } from 'yaml';
+import { ReactWidget } from '@jupyterlab/apputils';
+import { IDocumentManager } from '@jupyterlab/docmanager';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { CodeCell } from '@jupyterlab/cells';
+
+import { Box, ThemeProvider } from '@mui/material';
+
+import { theme } from '../themes/search';
+import { Search, SearchError, SearchQuery } from '../components/search';
+import { Query } from '../components/query/notebook';
+import { CompositeQuery, Composition } from '../components/query/fields';
+import { ResultEntity } from '../components/result/result';
+import {
+  NotebookSearchResponse,
+  performSearch,
+  prepareNotebook,
+  SearchTarget
+} from './handler';
+import { NotebookManager } from '../extensions/cellmanager';
+import { SolrQuery } from '../components/query/base';
+import { IndexedColumnId } from '../components/result/result';
+import { ResultColumn } from '../components/result/results';
+import { requestAPI } from '../handler';
+import { nbsearchIcon } from './icons';
+import {
+  showSectionSelectionDialog,
+  NotebookSection
+} from '../components/dialog/section-selection';
+
+type KeywordWithComposition = {
+  composition: Composition;
+  keyword: Keyword;
+};
+
+type KeywordWithSections = {
+  query: KeywordWithComposition;
+  sections: string[];
+};
+
+/**
+ * Get the output element from a CodeCell
+ */
+function getOutputElementFromCodeCell(codeCell: CodeCell): HTMLElement {
+  if (!codeCell || !codeCell.node) {
+    throw new Error('Invalid CodeCell provided');
+  }
+
+  // Find the output area within the cell
+  const outputArea = codeCell.node.querySelector('.jp-OutputArea-output');
+  if (outputArea) {
+    return outputArea as HTMLElement;
+  }
+
+  // If no existing output, create one
+  const outputAreaContainer = codeCell.node.querySelector('.jp-OutputArea');
+  if (outputAreaContainer) {
+    const outputElement = document.createElement('div');
+    outputElement.className = 'jp-OutputArea-output jp-RenderedWidget';
+    outputElement.setAttribute(
+      'data-mime-type',
+      'application/vnd.jupyter.widget-view+json'
+    );
+    outputAreaContainer.appendChild(outputElement);
+    return outputElement;
+  }
+  throw new Error('No output area found in the provided CodeCell');
+}
+
+type Keyword = {
+  [key: string]: string;
+};
+
+function getSolrQueryFromKeyword(keyword: KeywordWithComposition): string {
+  return Object.entries(keyword.keyword)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(keyword.composition === Composition.And ? ' AND ' : ' OR ');
+}
+
+function getCompositeQueryFromKeyword(
+  keyword: KeywordWithComposition
+): CompositeQuery {
+  const fields = Object.entries(keyword.keyword).map(([key, value]) => ({
+    target: key as IndexedColumnId,
+    query: value
+  }));
+
+  return {
+    composition: keyword.composition,
+    fields:
+      fields.length > 0
+        ? fields
+        : [
+            {
+              target: IndexedColumnId.FullText,
+              query: '*'
+            }
+          ]
+  };
+}
+
+function getKeywordFromCompositeQuery(
+  compositeQuery: CompositeQuery
+): KeywordWithComposition {
+  const keyword: Keyword = {};
+  for (const field of compositeQuery.fields) {
+    keyword[field.target] = field.query;
+  }
+  return {
+    composition: compositeQuery.composition,
+    keyword: keyword
+  };
+}
+
+function extractHeaderFromMarkdownCell(cell: any): string | null {
+  if (cell.cell_type !== 'markdown' || !cell.source) {
+    return null;
+  }
+
+  // Convert source to array of lines
+  const sourceLines = Array.isArray(cell.source)
+    ? cell.source
+    : cell.source.split('\n');
+
+  // Look for the first line that starts with # (ignoring empty lines)
+  for (const line of sourceLines) {
+    const trimmedLine = line.trim();
+    if (trimmedLine.startsWith('#')) {
+      return trimmedLine;
+    }
+    // If we encounter a non-empty line that's not a header, stop looking
+    if (trimmedLine.length > 0 && !trimmedLine.startsWith('#')) {
+      break;
+    }
+  }
+
+  return null;
+}
+
+function parseNotebookSections(cells: any[]): NotebookSection[] {
+  const sections: NotebookSection[] = [];
+  let currentSectionStart = 0;
+
+  for (let i = 0; i < cells.length; i++) {
+    const cell = cells[i];
+    const headerText = extractHeaderFromMarkdownCell(cell);
+
+    // Check if this is a markdown cell with a header
+    if (headerText) {
+      // If we have a previous section, add it
+      if (i > currentSectionStart) {
+        const prevHeaderCell = cells[currentSectionStart];
+        const prevTitle =
+          extractHeaderFromMarkdownCell(prevHeaderCell) ||
+          `Section ${sections.length + 1}`;
+
+        sections.push({
+          title: prevTitle,
+          startIndex: currentSectionStart,
+          endIndex: i - 1,
+          cells: cells.slice(currentSectionStart, i)
+        });
+      }
+
+      currentSectionStart = i;
+    }
+  }
+
+  // Add the last section
+  if (currentSectionStart < cells.length) {
+    const lastHeaderCell = cells[currentSectionStart];
+    const lastTitle =
+      extractHeaderFromMarkdownCell(lastHeaderCell) ||
+      `Section ${sections.length + 1}`;
+
+    sections.push({
+      title: lastTitle,
+      startIndex: currentSectionStart,
+      endIndex: cells.length - 1,
+      cells: cells.slice(currentSectionStart)
+    });
+  }
+
+  return sections;
+}
+
+type MagicSearchWidgetProps = {
+  currentCell: CodeCell;
+  documents: IDocumentManager;
+  notebookTracker: INotebookTracker;
+  notebookManager: NotebookManager;
+  keyword?: KeywordWithComposition;
+  lastSelectedSections?: string[];
+  onClosed?: (
+    inserted: boolean,
+    latestCompositeQuery?: CompositeQuery,
+    selectedSectionTitles?: string[]
+  ) => void;
+};
+const resultColumns: ResultColumn[] = [
+  {
+    id: IndexedColumnId.Path,
+    label: 'Path',
+    value: 'filename'
+  },
+  {
+    id: IndexedColumnId.Server,
+    label: 'Server',
+    value: 'signature_server_url'
+  },
+  {
+    id: IndexedColumnId.Owner,
+    label: 'Owner',
+    value: 'owner'
+  },
+  {
+    id: IndexedColumnId.Modified,
+    label: 'Modified',
+    value: 'mtime'
+  },
+  {
+    id: IndexedColumnId.Executed,
+    label: 'Executed',
+    value: 'lc_cell_meme__execution_end_time'
+  },
+  {
+    id: IndexedColumnId.OperationNote,
+    label: 'Operation Note',
+    value: 'source__markdown__operation_note'
+  },
+  {
+    id: IndexedColumnId.NumberOfHeaders,
+    label: '# of Headers',
+    value: 'source__markdown__heading_count'
+  }
+];
+
+const searchFields: IndexedColumnId[] = resultColumns
+  .map(r => r.id)
+  .concat([
+    IndexedColumnId.Cells,
+    IndexedColumnId.Outputs,
+    IndexedColumnId.CellMemes
+  ]);
+
+export function MagicSearchWidget({
+  currentCell,
+  documents,
+  notebookTracker,
+  notebookManager,
+  keyword,
+  lastSelectedSections,
+  onClosed
+}: MagicSearchWidgetProps): JSX.Element | null {
+  const [results, setResults] = useState<ResultEntity[]>([]);
+  const [page, setPage] = useState<{
+    start: number;
+    limit: number;
+    numFound: number;
+  } | null>(null);
+  const [error, setError] = useState<SearchError | undefined>(undefined);
+  const [isClosed, setIsClosed] = useState<boolean>(false);
+  const [latestCompositeQuery, setLatestCompositeQuery] = useState<
+    CompositeQuery | undefined
+  >(keyword ? getCompositeQueryFromKeyword(keyword) : undefined);
+
+  const searchHandler = useCallback(
+    (query: SearchQuery, finished: () => void) => {
+      performSearch<NotebookSearchResponse>(SearchTarget.Notebook, query)
+        .then(results => {
+          setError(undefined);
+          setResults(results.notebooks);
+          setPage({
+            start: results.start,
+            limit: results.limit,
+            numFound: results.numFound
+          });
+          finished();
+        })
+        .catch(error => {
+          setError(error);
+          finished();
+        });
+    },
+    []
+  );
+
+  const added = useCallback(
+    async (result: ResultEntity) => {
+      console.log('Selected result:', result);
+
+      // Call DataHandler with notebook_id
+      if (!result.id) {
+        console.warn('No notebook_id found in result');
+        return;
+      }
+      try {
+        const notebookData = await requestAPI<any>(`v1/data/${result.id}`);
+        console.log('DataHandler response:', notebookData);
+
+        // Get the current notebook and find the current cell's index
+        const currentNotebook = notebookTracker.currentWidget?.model;
+        if (!currentNotebook || !notebookData.notebook?.cells) {
+          console.warn('No current notebook or cells data');
+          return;
+        }
+
+        // Parse notebook into sections
+        const sections = parseNotebookSections(notebookData.notebook.cells);
+
+        // Show section selection dialog
+        const selectedSections = await showSectionSelectionDialog(
+          sections,
+          lastSelectedSections
+        );
+
+        if (!selectedSections || selectedSections.length === 0) {
+          console.log(
+            'Cell insertion cancelled by user or no sections selected'
+          );
+          return;
+        }
+
+        // Find the index of the current cell
+        const currentCellIndex = [...currentNotebook.cells].findIndex(
+          cell => cell.id === currentCell.model.id
+        );
+
+        if (currentCellIndex === -1) {
+          console.warn('Current cell not found in notebook');
+          return;
+        }
+
+        // selectedSections is already validated above
+
+        // Insert cells from selected sections after the current cell
+        let insertIndex = currentCellIndex + 1;
+        let totalInsertedCells = 0;
+
+        for (const section of selectedSections) {
+          for (const cellData of section.cells) {
+            const newCell = {
+              cell_type: cellData.cell_type,
+              source: cellData.source,
+              metadata: cellData.metadata || {},
+              trusted: true
+            };
+            currentNotebook.sharedModel.insertCell(insertIndex, newCell);
+            insertIndex++;
+            totalInsertedCells++;
+          }
+        }
+
+        console.log(
+          `Inserted ${totalInsertedCells} cells from ${selectedSections.length} sections after current cell`,
+          'Latest composite query:',
+          latestCompositeQuery
+        );
+
+        // Close the search display
+        setIsClosed(true);
+        if (onClosed) {
+          const selectedSectionTitles = selectedSections.map(
+            section => section.title
+          );
+          onClosed(true, latestCompositeQuery, selectedSectionTitles);
+        }
+      } catch (error) {
+        console.error('Error calling DataHandler:', error);
+      }
+    },
+    [notebookTracker, currentCell, latestCompositeQuery, onClosed, documents]
+  );
+  const selected = useCallback(
+    (result: ResultEntity) => {
+      prepareNotebook('/nbsearch-tmp', result.id)
+        .then(result => {
+          documents.openOrReveal(`/nbsearch-tmp/${result.filename}`);
+        })
+        .catch(error => {
+          setError(error);
+        });
+    },
+    [documents]
+  );
+
+  if (isClosed) {
+    return null;
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box
+        className="nbsearch-magic-root"
+        sx={{ border: '2px solid #1976d2', borderRadius: 2, p: 2, m: 1 }}
+      >
+        <Box sx={{ mb: 2, fontWeight: 'bold', color: '#1976d2', fontSize: 18 }}>
+          <span
+            dangerouslySetInnerHTML={{ __html: nbsearchIcon }}
+            style={{ marginRight: '8px', display: 'inline-block' }}
+          />
+          NBSearch
+        </Box>
+        <Search
+          columns={resultColumns}
+          onSearch={searchHandler}
+          onResultSelect={selected}
+          showAddButton={true}
+          onResultAdd={added}
+          defaultQuery={
+            keyword
+              ? { queryString: getSolrQueryFromKeyword(keyword) }
+              : { queryString: '_text_:*' }
+          }
+          queryFactory={solrQueryChanged => (
+            <Query
+              fields={searchFields}
+              onChange={(query: SolrQuery, compositeQuery?: CompositeQuery) => {
+                // Update latest composite query if available
+                if (compositeQuery) {
+                  console.log('Composite query changed:', compositeQuery);
+                  setLatestCompositeQuery(compositeQuery);
+                }
+                solrQueryChanged({
+                  get: () => query
+                });
+              }}
+              initialFieldsValue={
+                keyword ? getCompositeQueryFromKeyword(keyword) : undefined
+              }
+            ></Query>
+          )}
+          queryContext={{}}
+          start={page?.start}
+          limit={page?.limit}
+          numFound={page?.numFound}
+          results={results}
+          error={error}
+          onClosed={
+            onClosed
+              ? () => onClosed(false, latestCompositeQuery, [])
+              : undefined
+          }
+        />
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+export function createMagicSearchWidget(
+  documents: IDocumentManager,
+  notebookTracker: INotebookTracker,
+  notebookManager: NotebookManager,
+  keywordWithSections: Keyword | KeywordWithSections,
+  codeCell: CodeCell
+): void {
+  // Get output element from the CodeCell
+  const outputElement = getOutputElementFromCodeCell(codeCell);
+  let outputWrapper: HTMLElement | null = null;
+  const keyword: KeywordWithComposition = (
+    keywordWithSections.query as KeywordWithComposition
+  )?.composition
+    ? (keywordWithSections.query as KeywordWithComposition)
+    : {
+        composition: Composition.And,
+        keyword: keywordWithSections as Keyword
+      };
+  const lastSelectedSections: string[] = (
+    keywordWithSections.query as KeywordWithComposition
+  )?.composition
+    ? (keywordWithSections as KeywordWithSections).sections
+    : [];
+
+  // Create a custom ReactWidget class for output area mounting (multi-outputs pattern)
+  class MagicSearchOutputWidget extends ReactWidget {
+    constructor() {
+      super();
+      this.addClass('nbsearch-magic-output-widget');
+      this.addClass('jp-RenderedWidget');
+    }
+
+    render(): JSX.Element {
+      return (
+        <MagicSearchWidget
+          currentCell={codeCell}
+          documents={documents}
+          notebookTracker={notebookTracker}
+          notebookManager={notebookManager}
+          keyword={keyword}
+          lastSelectedSections={lastSelectedSections}
+          onClosed={(
+            inserted: boolean,
+            latestCompositeQuery?: CompositeQuery,
+            selectedSectionTitles?: string[]
+          ) => {
+            // Use the latest composite query if available, otherwise fall back to original keyword
+            const keywordToUse = latestCompositeQuery
+              ? getKeywordFromCompositeQuery(latestCompositeQuery)
+              : keyword || {};
+
+            // Convert keyword to YAML and set as cell source
+            let yamlLines: string[] = ['%%nbsearch'];
+            const yamlData: KeywordWithSections = {
+              query: keywordToUse,
+              sections: selectedSectionTitles || []
+            };
+            yamlLines = yamlLines.concat(
+              stringify(yamlData).trim().split('\n')
+            );
+            if (inserted) {
+              yamlLines = yamlLines.map(line => `# ${line}`);
+            }
+            const yamlString = yamlLines.join('\n');
+            codeCell.model.sharedModel.setSource(yamlString);
+
+            if (outputWrapper) {
+              outputWrapper.style.display = 'none';
+            }
+          }}
+        />
+      );
+    }
+
+    // Public method to trigger attach lifecycle
+    public triggerAttach(): void {
+      try {
+        this.onAfterAttach(null);
+        console.log('MagicSearchOutputWidget attached successfully');
+      } catch (error) {
+        console.warn('Error triggering attach:', error);
+      }
+    }
+
+    // Public method to trigger detach lifecycle
+    public triggerDetach(): void {
+      try {
+        this.onBeforeDetach(null);
+        console.log('MagicSearchOutputWidget detaching');
+      } catch (error) {
+        console.warn('Error triggering detach:', error);
+      }
+    }
+
+    protected onAfterAttach(msg: any): void {
+      super.onAfterAttach(msg);
+    }
+
+    protected onBeforeDetach(msg: any): void {
+      super.onBeforeDetach(msg);
+    }
+  }
+
+  const widget = new MagicSearchOutputWidget();
+  console.log('Custom ReactWidget created:', widget);
+
+  mountToOutputArea(widget, outputElement);
+
+  // Mount widget to output area using multi-outputs pattern
+  function mountToOutputArea(widget: any, element: HTMLElement) {
+    element.innerHTML = '';
+
+    outputWrapper = document.createElement('div');
+    outputWrapper.className = 'jp-OutputArea-output jp-RenderedWidget';
+    outputWrapper.setAttribute(
+      'data-mime-type',
+      'application/vnd.jupyter.widget-view+json'
+    );
+    outputWrapper.style.cssText = `
+        width: 100%;
+        overflow: visible;
+        display: block;
+        position: relative;
+      `;
+
+    // Add the wrapper to the output element first
+    element.appendChild(outputWrapper);
+
+    // Now attach the widget to the wrapper
+    if (!widget.node) {
+      console.error('Widget node is not available, ignoring mount');
+      return;
+    }
+
+    // Set widget node styles for proper output area display
+    widget.node.style.cssText = `
+          width: 100%;
+          display: block;
+          overflow: visible;
+          min-height: 200px;
+        `;
+
+    outputWrapper.appendChild(widget.node);
+
+    // Trigger widget lifecycle - this is crucial for multi-outputs
+    setTimeout(() => {
+      try {
+        // Call onAfterAttach to properly initialize the widget
+        widget.triggerAttach();
+        console.log('Widget lifecycle events triggered successfully');
+      } catch (lifecycleError) {
+        console.warn('Widget lifecycle error (non-critical):', lifecycleError);
+      }
+    }, 100);
+  }
+}

--- a/src/widgets/magic-search.tsx
+++ b/src/widgets/magic-search.tsx
@@ -413,7 +413,7 @@ export function MagicSearchWidget({
               ? { queryString: getSolrQueryFromKeyword(keyword) }
               : { queryString: '_text_:*' }
           }
-          queryFactory={solrQueryChanged => (
+          queryFactory={(solrQueryChanged, onSearch) => (
             <Query
               fields={searchFields}
               onChange={(query: SolrQuery, compositeQuery?: CompositeQuery) => {
@@ -426,6 +426,7 @@ export function MagicSearchWidget({
                   get: () => query
                 });
               }}
+              onSearch={onSearch}
               initialFieldsValue={
                 keyword ? getCompositeQueryFromKeyword(keyword) : undefined
               }

--- a/src/widgets/magic-search.tsx
+++ b/src/widgets/magic-search.tsx
@@ -408,6 +408,7 @@ export function MagicSearchWidget({
           onResultSelect={selected}
           showAddButton={true}
           onResultAdd={added}
+          autoSearch={true}
           defaultQuery={
             keyword
               ? { queryString: getSolrQueryFromKeyword(keyword) }
@@ -419,7 +420,6 @@ export function MagicSearchWidget({
               onChange={(query: SolrQuery, compositeQuery?: CompositeQuery) => {
                 // Update latest composite query if available
                 if (compositeQuery) {
-                  console.log('Composite query changed:', compositeQuery);
                   setLatestCompositeQuery(compositeQuery);
                 }
                 solrQueryChanged({

--- a/src/widgets/tree-search.tsx
+++ b/src/widgets/tree-search.tsx
@@ -139,6 +139,7 @@ export function SearchWidget(props: SearchWidgetProps): JSX.Element {
           columns={resultColumns}
           onSearch={searchHandler}
           onResultSelect={selected}
+          autoSearch={true}
           defaultQuery={{
             queryString: '_text_:*'
           }}

--- a/src/widgets/tree-search.tsx
+++ b/src/widgets/tree-search.tsx
@@ -142,7 +142,7 @@ export function SearchWidget(props: SearchWidgetProps): JSX.Element {
           defaultQuery={{
             queryString: '_text_:*'
           }}
-          queryFactory={solrQueryChanged => (
+          queryFactory={(solrQueryChanged, onSearch) => (
             <Query
               fields={searchFields}
               onChange={(query: SolrQuery) =>
@@ -150,6 +150,7 @@ export function SearchWidget(props: SearchWidgetProps): JSX.Element {
                   get: () => query
                 })
               }
+              onSearch={onSearch}
             ></Query>
           )}
           queryContext={{}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8996,6 +8996,7 @@ __metadata:
     stylelint-csstree-validator: ^3.0.0
     stylelint-prettier: ^4.0.0
     typescript: ~5.0.2
+    yaml: ^2.8.0
     yjs: ^13.5.0
   languageName: unknown
   linkType: soft
@@ -11753,6 +11754,15 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "yaml@npm:2.8.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 66f103ca5a2f02dac0526895cc7ae7626d91aa8c43aad6fdcff15edf68b1199be4012140b390063877913441aaa5288fdf57eca30e06268a8282dd741525e626
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add `%%nbsearch` magic commands for searching and inserting notebook cells directly within Jupyter notebooks. This magic is inspired by [jupyter-ai](https://github.com/jupyterlab/jupyter-ai) `%%ai`, which allows AI-assisted interactions via magic cells. Like `%%ai`, this magic helps document how external content is introduced into the notebook, improving transparency.

When a cell begins with `%%nbsearch`, a search interface is launched, allowing users to locate and insert content from other notebooks.

![magic-command](https://github.com/user-attachments/assets/59e7127b-687c-4cc9-a1ef-c4a2cfbd0958)


The magic behaves as follows:

* Displays a search panel within the notebook UI upon execution.
* Enables preview of notebooks matching the query.
* Allows users to click an **Add** button to initiate insertion.
* Opens a dialog for selecting specific sections (headings) to import.
* Injects the selected content directly into the current notebook.
* Auto-generates and appends the corresponding search query to the `%%nbsearch` cell as a commented line.
* Users may uncomment and reuse the query for iterative or refined searches.

By recording users’ search actions directly in the notebook, `%%nbsearch` enhances the reproducibility of notebook creation—not only preserving results, but also the process that led to them.

This PR includes several other improvements:

- Enabling search by pressing Enter in the keyword field
- Fixed the workflow for GitHub Actions