### PR TITLE
Add URL parameter support for search queries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Build artifacts
+nbsearch/labextension/
+lib/
+node_modules/
+*.egg-info/
+__pycache__/
+
+# Version control
+.git/
+.github/
+
+# Development tools
+.vscode/
+.virtual_documents/
+.ipynb_checkpoints/
+.pytest_cache/
+.yarn/
+
+# Python cache
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# TypeScript build info
+tsconfig.tsbuildinfo
+
+# Coverage reports
+coverage/
+htmlcov/
+.coverage
+
+# Test artifacts
+junit.xml
+.pytest_cache/
+
+# Temporary files
+*.log
+*.tmp
+*~
+.DS_Store
+
+# Notebooks
+*.ipynb
+!example/*.ipynb
+
+# Other temp directories
+nbsearch-tmp/
+binder/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
 FROM solr:8 AS solr
 
-FROM jupyter/scipy-notebook:latest
+FROM quay.io/jupyter/scipy-notebook:notebook-7.4.5
 
 USER root
 
 # Install OpenJDK and lsyncd
 RUN apt-get update && apt-get install -yq supervisor lsyncd uuid-runtime \
-    openjdk-11-jre gnupg curl tinyproxy netcat \
+    openjdk-11-jre gnupg curl tinyproxy netcat-openbsd \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20.x (required for JupyterLab extensions)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && \
+    mkdir -p /.npm && \
+    chown jovyan:users -R /.npm && \
+    rm -rf /var/lib/apt/lists/*
+ENV NPM_CONFIG_PREFIX=/.npm
+ENV PATH=/.npm/bin/:${PATH}
 
 # Solr
 COPY --from=solr /opt /opt/

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ The NBSearch pane allows searching of cells. You can search for preceding and su
 
 The `%%nbsearch` magic command provides a convenient way to search and insert notebook cells directly within your notebook.
 
+First, load the nbsearch magic extension:
+```python
+%load_ext nbsearch.magics
+```
+
+Then you can use the magic command:
 ![NBSearch Magic Command](./images/magic-command.gif)
 
 #### Simple String Query

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.0",
         "codemirror": "^5.65.16",
+        "liqe": "^3.8.3",
         "yaml": "^2.8.0"
     },
     "devDependencies": {

--- a/src/__tests__/utils/query-parser.spec.ts
+++ b/src/__tests__/utils/query-parser.spec.ts
@@ -1,0 +1,256 @@
+import {
+  parseSolrToComposite,
+  compositeToSolr,
+  canConvertToStructured,
+  simplifySolrQuery,
+  expandSimplifiedQuery
+} from '../../utils/query-parser';
+import { Composition } from '../../components/query/fields';
+import { IndexedColumnId } from '../../components/result/result';
+
+describe('Query Parser', () => {
+  describe('parseSolrToComposite', () => {
+    it('should parse simple text query', () => {
+      const result = parseSolrToComposite('python');
+      expect(result).toEqual({
+        composition: Composition.Or,
+        fields: [{
+          target: IndexedColumnId.FullText,
+          query: 'python'
+        }]
+      });
+    });
+
+    it('should parse _text_ field query', () => {
+      const result = parseSolrToComposite('_text_:python');
+      expect(result).toEqual({
+        composition: Composition.Or,
+        fields: [{
+          target: IndexedColumnId.FullText,
+          query: 'python'
+        }]
+      });
+    });
+
+    it('should parse owner field query', () => {
+      const result = parseSolrToComposite('owner:yazawa');
+      expect(result).toEqual({
+        composition: Composition.Or,
+        fields: [{
+          target: IndexedColumnId.Owner,
+          query: 'yazawa'
+        }]
+      });
+    });
+
+    it('should parse MEME field query', () => {
+      const result = parseSolrToComposite('lc_cell_memes:fc68b4b4-2927-11e9-b46c-0242ac110002');
+      expect(result).toEqual({
+        composition: Composition.Or,
+        fields: [{
+          target: IndexedColumnId.CellMemes,
+          query: 'fc68b4b4-2927-11e9-b46c-0242ac110002'
+        }]
+      });
+    });
+
+    it('should parse AND query with two fields', () => {
+      const result = parseSolrToComposite('owner:yazawa AND source:pandas');
+      expect(result).toEqual({
+        composition: Composition.And,
+        fields: [
+          {
+            target: IndexedColumnId.Owner,
+            query: 'yazawa'
+          },
+          {
+            target: IndexedColumnId.Cells,
+            query: 'pandas'
+          }
+        ]
+      });
+    });
+
+    it('should parse OR query with two fields', () => {
+      const result = parseSolrToComposite('owner:yazawa OR source:matplotlib');
+      expect(result).toEqual({
+        composition: Composition.Or,
+        fields: [
+          {
+            target: IndexedColumnId.Owner,
+            query: 'yazawa'
+          },
+          {
+            target: IndexedColumnId.Cells,
+            query: 'matplotlib'
+          }
+        ]
+      });
+    });
+
+    it('should return null for complex nested queries', () => {
+      const result = parseSolrToComposite('(owner:yazawa OR owner:tanaka) AND source:pandas');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for unknown fields', () => {
+      const result = parseSolrToComposite('unknown_field:value');
+      expect(result).toBeNull();
+    });
+
+    it('should parse quoted values', () => {
+      const result = parseSolrToComposite('owner:"John Doe"');
+      expect(result).toEqual({
+        composition: Composition.Or,
+        fields: [{
+          target: IndexedColumnId.Owner,
+          query: 'John Doe'
+        }]
+      });
+    });
+  });
+
+  describe('compositeToSolr', () => {
+    it('should convert single field to Solr query', () => {
+      const result = compositeToSolr({
+        composition: Composition.Or,
+        fields: [{
+          target: IndexedColumnId.FullText,
+          query: 'python'
+        }]
+      });
+      expect(result).toBe('_text_:python');
+    });
+
+    it('should convert owner field to Solr query', () => {
+      const result = compositeToSolr({
+        composition: Composition.Or,
+        fields: [{
+          target: IndexedColumnId.Owner,
+          query: 'yazawa'
+        }]
+      });
+      expect(result).toBe('owner:yazawa');
+    });
+
+    it('should convert multiple fields with AND', () => {
+      const result = compositeToSolr({
+        composition: Composition.And,
+        fields: [
+          {
+            target: IndexedColumnId.Owner,
+            query: 'yazawa'
+          },
+          {
+            target: IndexedColumnId.Cells,
+            query: 'pandas'
+          }
+        ]
+      });
+      expect(result).toBe('owner:yazawa AND source:pandas');
+    });
+
+    it('should convert multiple fields with OR', () => {
+      const result = compositeToSolr({
+        composition: Composition.Or,
+        fields: [
+          {
+            target: IndexedColumnId.Owner,
+            query: 'yazawa'
+          },
+          {
+            target: IndexedColumnId.Cells,
+            query: 'matplotlib'
+          }
+        ]
+      });
+      expect(result).toBe('owner:yazawa OR source:matplotlib');
+    });
+
+    it('should handle empty fields', () => {
+      const result = compositeToSolr({
+        composition: Composition.Or,
+        fields: []
+      });
+      expect(result).toBe('_text_:*');
+    });
+  });
+
+  describe('canConvertToStructured', () => {
+    it('should return true for simple queries', () => {
+      expect(canConvertToStructured('python')).toBe(true);
+      expect(canConvertToStructured('_text_:python')).toBe(true);
+      expect(canConvertToStructured('owner:yazawa')).toBe(true);
+    });
+
+    it('should return true for simple AND/OR queries', () => {
+      expect(canConvertToStructured('owner:yazawa AND source:pandas')).toBe(true);
+      expect(canConvertToStructured('owner:yazawa OR source:pandas')).toBe(true);
+    });
+
+    it('should return false for complex queries', () => {
+      expect(canConvertToStructured('(owner:yazawa OR owner:tanaka) AND source:pandas')).toBe(false);
+      expect(canConvertToStructured('unknown_field:value')).toBe(false);
+    });
+  });
+
+  describe('simplifySolrQuery', () => {
+    it('should simplify _text_: prefix for simple queries', () => {
+      expect(simplifySolrQuery('_text_:python')).toBe('python');
+      expect(simplifySolrQuery('_text_:jupyter')).toBe('jupyter');
+    });
+
+    it('should not simplify field queries', () => {
+      expect(simplifySolrQuery('owner:yazawa')).toBe('owner:yazawa');
+      expect(simplifySolrQuery('source:pandas')).toBe('source:pandas');
+    });
+
+    it('should not simplify complex queries with _text_', () => {
+      expect(simplifySolrQuery('_text_:python AND owner:yazawa')).toBe('_text_:python AND owner:yazawa');
+      expect(simplifySolrQuery('_text_:python OR owner:yazawa')).toBe('_text_:python OR owner:yazawa');
+    });
+  });
+
+  describe('expandSimplifiedQuery', () => {
+    it('should expand simple text to _text_: query', () => {
+      expect(expandSimplifiedQuery('python')).toBe('_text_:python');
+      expect(expandSimplifiedQuery('jupyter')).toBe('_text_:jupyter');
+    });
+
+    it('should not expand field queries', () => {
+      expect(expandSimplifiedQuery('owner:yazawa')).toBe('owner:yazawa');
+      expect(expandSimplifiedQuery('source:pandas')).toBe('source:pandas');
+    });
+
+    it('should not expand wildcard', () => {
+      expect(expandSimplifiedQuery('*')).toBe('*');
+    });
+
+    it('should not expand already expanded queries', () => {
+      expect(expandSimplifiedQuery('_text_:python')).toBe('_text_:python');
+    });
+  });
+
+  describe('Round-trip conversion', () => {
+    it('should preserve simple queries', () => {
+      const queries = [
+        'python',
+        '_text_:python',
+        'owner:yazawa',
+        'lc_cell_memes:abc123',
+        'owner:yazawa AND source:pandas',
+        'owner:yazawa OR source:matplotlib'
+      ];
+
+      queries.forEach(query => {
+        const composite = parseSolrToComposite(query);
+        if (composite) {
+          const solr = compositeToSolr(composite);
+          const normalized = expandSimplifiedQuery(query);
+          // Compare normalized forms
+          expect(solr).toBe(normalized.includes(':') ? normalized : `_text_:${normalized}`);
+        }
+      });
+    });
+  });
+});

--- a/src/__tests__/utils/url-params.spec.ts
+++ b/src/__tests__/utils/url-params.spec.ts
@@ -1,0 +1,186 @@
+import {
+  getSearchParamsFromURL,
+  updateURLSearchParams,
+  searchQueryToURLParams,
+  urlParamsToSearchQuery,
+  hasSearchParams
+} from '../../utils/url-params';
+import { SortOrder } from '../../components/result/results';
+import { IndexedColumnId } from '../../components/result/result';
+
+describe('URL Parameters', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    // Save original location
+    originalLocation = window.location;
+    // Mock window.location
+    delete (window as any).location;
+    (window as any).location = {
+      href: 'http://localhost:8889/lab',
+      search: '',
+      toString: () => window.location.href
+    };
+    // Mock window.history.replaceState
+    window.history.replaceState = jest.fn();
+  });
+
+  afterEach(() => {
+    // Restore original location
+    (window as any).location = originalLocation;
+  });
+
+  describe('getSearchParamsFromURL', () => {
+    it('should parse solrquery parameter', () => {
+      window.location.search = '?solrquery=owner:yazawa';
+      const params = getSearchParamsFromURL();
+      expect(params.solrquery).toBe('owner:yazawa');
+    });
+
+    it('should parse sort parameter', () => {
+      window.location.search = '?sort=mtime desc';
+      const params = getSearchParamsFromURL();
+      expect(params.sort).toBe('mtime desc');
+    });
+
+    it('should parse numeric parameters', () => {
+      window.location.search = '?start=10&limit=50&size=0&numFound=100';
+      const params = getSearchParamsFromURL();
+      expect(params.start).toBe(10);
+      expect(params.limit).toBe(50);
+      expect(params.size).toBe(0);
+      expect(params.numFound).toBe(100);
+    });
+
+    it('should parse nbsearch parameter', () => {
+      window.location.search = '?nbsearch=yes';
+      const params = getSearchParamsFromURL();
+      expect(params.nbsearch).toBe('yes');
+    });
+
+    it('should handle empty parameters', () => {
+      window.location.search = '';
+      const params = getSearchParamsFromURL();
+      expect(params).toEqual({});
+    });
+  });
+
+  describe('urlParamsToSearchQuery', () => {
+    it('should convert solrquery to queryString', () => {
+      const query = urlParamsToSearchQuery({
+        solrquery: 'owner:yazawa AND source:pandas'
+      });
+      expect(query.queryString).toBe('owner:yazawa AND source:pandas');
+    });
+
+    it('should parse sort format', () => {
+      const query = urlParamsToSearchQuery({
+        sort: 'mtime desc'
+      });
+      expect(query.sortQuery).toEqual({
+        column: 'mtime',
+        order: SortOrder.Descending
+      });
+    });
+
+    it('should handle pagination parameters', () => {
+      const query = urlParamsToSearchQuery({
+        start: 20,
+        limit: 100
+      });
+      expect(query.pageQuery).toEqual({
+        start: 20,
+        limit: 100
+      });
+    });
+
+    it('should use defaults for missing pagination', () => {
+      const query = urlParamsToSearchQuery({});
+      expect(query.pageQuery).toBeUndefined();
+
+      const queryWithStart = urlParamsToSearchQuery({ start: 10 });
+      expect(queryWithStart.pageQuery).toEqual({
+        start: 10,
+        limit: 50
+      });
+    });
+  });
+
+  describe('searchQueryToURLParams', () => {
+    it('should convert queryString to solrquery', () => {
+      const params = searchQueryToURLParams({
+        queryString: 'owner:yazawa'
+      });
+      expect(params.solrquery).toBe('owner:yazawa');
+      expect(params.nbsearch).toBe('yes');
+    });
+
+    it('should convert sortQuery to sort string', () => {
+      const params = searchQueryToURLParams({
+        queryString: '_text_:*',
+        sortQuery: {
+          column: IndexedColumnId.Modified,
+          order: SortOrder.Descending
+        }
+      });
+      expect(params.sort).toBe('mtime desc');
+    });
+
+    it('should include pagination', () => {
+      const params = searchQueryToURLParams({
+        queryString: '_text_:*',
+        pageQuery: {
+          start: 10,
+          limit: 25
+        }
+      });
+      expect(params.start).toBe(10);
+      expect(params.limit).toBe(25);
+    });
+  });
+
+  describe('hasSearchParams', () => {
+    it('should return true when nbsearch=yes', () => {
+      window.location.search = '?nbsearch=yes&solrquery=python';
+      expect(hasSearchParams()).toBe(true);
+    });
+
+    it('should return false when nbsearch is not yes', () => {
+      window.location.search = '?nbsearch=no&solrquery=python';
+      expect(hasSearchParams()).toBe(false);
+    });
+
+    it('should return false when no nbsearch parameter', () => {
+      window.location.search = '?solrquery=python';
+      expect(hasSearchParams()).toBe(false);
+    });
+  });
+
+  describe('updateURLSearchParams', () => {
+    it('should update URL with new parameters', () => {
+      updateURLSearchParams({
+        solrquery: 'owner:yazawa',
+        limit: 100,
+        nbsearch: 'yes'
+      });
+
+      expect(window.history.replaceState).toHaveBeenCalled();
+      const call = (window.history.replaceState as jest.Mock).mock.calls[0];
+      const url = call[2];
+      expect(url).toContain('solrquery=owner%3Ayazawa');
+      expect(url).toContain('limit=100');
+      expect(url).toContain('nbsearch=yes');
+    });
+
+    it('should remove default values', () => {
+      window.location.search = '?solrquery=test&limit=50';
+      updateURLSearchParams({
+        solrquery: '_text_:*'
+      });
+
+      const call = (window.history.replaceState as jest.Mock).mock.calls[0];
+      const url = call[2];
+      expect(url).not.toContain('solrquery');
+    });
+  });
+});

--- a/src/components/query/cell.tsx
+++ b/src/components/query/cell.tsx
@@ -170,7 +170,6 @@ export type QueryProps = {
   onChange?: (query: LazySolrQuery, compositeQuery?: CompositeQuery) => void;
   onSearch?: () => void;
   fields?: IndexedColumnId[];
-  initialFieldsValue?: CompositeQuery;
 };
 
 export function Query({
@@ -178,8 +177,7 @@ export function Query({
   onSearch,
   targetCell,
   location,
-  fields,
-  initialFieldsValue
+  fields
 }: QueryProps): JSX.Element {
   const [solrQuery, setSolrQuery] = useState<SolrQuery>({
     queryString: '_text_:*'
@@ -288,7 +286,7 @@ export function Query({
           fields={fields}
           onChange={fieldsChanged}
           onSearch={onSearch}
-          initialValue={initialFieldsValue}
+          value={fieldsCompositeQuery}
         />
       </TabPanel>
       <TabPanel id={TabIndex.Solr} value={tabIndex}>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Common constants used across the nbsearch extension
+ */
+
+export const LOG_PREFIX = '[nbsearch]';

--- a/src/utils/query-parser.ts
+++ b/src/utils/query-parser.ts
@@ -1,0 +1,175 @@
+import {
+  parse,
+  LiqeQuery,
+  ParserAst,
+  TagToken,
+  LogicalExpressionToken,
+  LiteralExpressionToken,
+  FieldToken,
+  ImplicitFieldToken
+} from 'liqe';
+import { CompositeQuery, Composition, ALL_FIELDS } from '../components/query/fields';
+import { IndexedColumnId } from '../components/result/result';
+
+// Create a set of supported field names for quick lookup
+// These are the fields that can be converted between Solr query and structured query
+const SUPPORTED_FIELD_NAMES = new Set(ALL_FIELDS.map(field => field.id));
+
+// Check if a field name is supported in the Search by fields UI
+function isSupportedField(fieldName: string): fieldName is IndexedColumnId {
+  return SUPPORTED_FIELD_NAMES.has(fieldName as IndexedColumnId);
+}
+
+/**
+ * Parse a Solr query string and convert it to a CompositeQuery if possible
+ * @param solrQuery The Solr query string
+ * @returns CompositeQuery if the query can be structured, null otherwise
+ */
+export function parseSolrToComposite(solrQuery: string): CompositeQuery | null {
+  try {
+    // Parse using liqe
+    const ast = parse(solrQuery);
+
+    // Try to convert AST to CompositeQuery
+    return astToComposite(ast);
+  } catch (error) {
+    console.warn('[Query Parser] Failed to parse Solr query:', error);
+    return null;
+  }
+}
+
+/**
+ * Convert a liqe AST to CompositeQuery
+ */
+function astToComposite(ast: ParserAst | LiqeQuery): CompositeQuery | null {
+  // Handle simple field query
+  if (ast.type === 'Tag') {
+    const tagAst = ast as TagToken;
+    const field = tagAst.field as FieldToken | ImplicitFieldToken;
+    // Use '_text_' for implicit fields (no field specified)
+    const fieldName = field.type === 'Field' ? field.name : '_text_';
+
+    // Check if this field is supported in the Search by fields UI
+    if (!isSupportedField(fieldName)) {
+      // Unknown or unsupported field, cannot convert to structured query
+      return null;
+    }
+
+    // Get the value from the expression
+    let value = '';
+    if (tagAst.expression.type === 'LiteralExpression') {
+      const expr = tagAst.expression as LiteralExpressionToken;
+      value = String(expr.value);
+    } else if (tagAst.expression.type === 'EmptyExpression') {
+      value = '*';
+    }
+
+    return {
+      composition: Composition.Or,
+      fields: [{
+        target: fieldName as IndexedColumnId,
+        query: value
+      }]
+    };
+  }
+
+  // Handle logical expressions (AND/OR)
+  if (ast.type === 'LogicalExpression') {
+    const logicalAst = ast as LogicalExpressionToken;
+    const operator = logicalAst.operator.operator;
+    const composition = operator === 'AND' ? Composition.And : Composition.Or;
+
+    // Collect all field queries
+    const fields = [];
+
+    for (const operand of [logicalAst.left, logicalAst.right]) {
+      const subComposite = astToComposite(operand);
+      if (!subComposite) {
+        // If any part cannot be converted, bail out
+        return null;
+      }
+
+      // Check if compositions match
+      if (subComposite.composition !== composition && subComposite.fields.length > 1) {
+        // Mixed compositions, cannot represent in simple CompositeQuery
+        return null;
+      }
+
+      fields.push(...subComposite.fields);
+    }
+
+    return {
+      composition,
+      fields
+    };
+  }
+
+  // Handle parenthesized expressions
+  if (ast.type === 'ParenthesizedExpression') {
+    // For now, we don't support complex parenthesized expressions
+    return null;
+  }
+
+  // Handle unary operators (NOT, -)
+  if (ast.type === 'UnaryOperator') {
+    // For now, we don't support NOT operators
+    return null;
+  }
+
+  // Cannot convert complex queries
+  return null;
+}
+
+/**
+ * Convert a CompositeQuery to a Solr query string
+ */
+export function compositeToSolr(composite: CompositeQuery): string {
+  if (composite.fields.length === 0) {
+    return '_text_:*';
+  }
+
+  if (composite.fields.length === 1) {
+    const field = composite.fields[0];
+    // field.target is already the Solr field name (IndexedColumnId value)
+    return `${field.target}:${field.query}`;
+  }
+
+  // Multiple fields
+  const operator = composite.composition === Composition.And ? ' AND ' : ' OR ';
+  const parts = composite.fields.map(field => {
+    // field.target is already the Solr field name (IndexedColumnId value)
+    return `${field.target}:${field.query}`;
+  });
+
+  return parts.join(operator);
+}
+
+/**
+ * Check if a Solr query can be represented as a structured query
+ */
+export function canConvertToStructured(solrQuery: string): boolean {
+  return parseSolrToComposite(solrQuery) !== null;
+}
+
+/**
+ * Simplify a Solr query for URL storage
+ * Remove unnecessary _text_: prefix for simple queries
+ */
+export function simplifySolrQuery(solrQuery: string): string {
+  // Simple _text_: queries can be simplified
+  if (solrQuery.startsWith('_text_:') && !solrQuery.includes(' AND ') && !solrQuery.includes(' OR ')) {
+    return solrQuery.substring(7); // Remove "_text_:"
+  }
+  return solrQuery;
+}
+
+/**
+ * Expand a simplified query back to full Solr format
+ */
+export function expandSimplifiedQuery(query: string): string {
+  // If it doesn't contain a field specifier and isn't already a Solr query
+  if (!query.includes(':') && query !== '*') {
+    return `_text_:${query}`;
+  }
+  return query;
+}

--- a/src/utils/url-params.ts
+++ b/src/utils/url-params.ts
@@ -1,0 +1,191 @@
+import { SearchQuery } from '../components/search';
+import { SortOrder } from '../components/result/results';
+import { IndexedColumnId } from '../components/result/result';
+
+export interface URLSearchParams {
+  solrquery?: string;
+  sort?: string;
+  start?: number;
+  limit?: number;
+  size?: number;
+  numFound?: number;
+  error?: string;
+  nbsearch?: string;
+}
+
+export function getSearchParamsFromURL(): URLSearchParams {
+  const params = new URLSearchParams(window.location.search);
+  const result: URLSearchParams = {};
+
+  const solrquery = params.get('solrquery');
+  if (solrquery) {
+    result.solrquery = solrquery;
+  }
+
+  const sort = params.get('sort');
+  if (sort) {
+    result.sort = sort;
+  }
+
+  const start = params.get('start');
+  if (start) {
+    const startNum = parseInt(start, 10);
+    if (!isNaN(startNum) && startNum >= 0) {
+      result.start = startNum;
+    }
+  }
+
+  const limit = params.get('limit');
+  if (limit) {
+    const limitNum = parseInt(limit, 10);
+    if (!isNaN(limitNum) && limitNum > 0) {
+      result.limit = limitNum;
+    }
+  }
+
+  const size = params.get('size');
+  if (size) {
+    const sizeNum = parseInt(size, 10);
+    if (!isNaN(sizeNum) && sizeNum >= 0) {
+      result.size = sizeNum;
+    }
+  }
+
+  const numFound = params.get('numFound');
+  if (numFound) {
+    const numFoundNum = parseInt(numFound, 10);
+    if (!isNaN(numFoundNum) && numFoundNum >= 0) {
+      result.numFound = numFoundNum;
+    }
+  }
+
+  const error = params.get('error');
+  if (error) {
+    result.error = error;
+  }
+
+  const nbsearch = params.get('nbsearch');
+  if (nbsearch) {
+    result.nbsearch = nbsearch;
+  }
+
+  return result;
+}
+
+export function updateURLSearchParams(params: URLSearchParams): void {
+  const url = new URL(window.location.href);
+  const searchParams = new URLSearchParams(url.search);
+
+  // Update or remove each parameter
+  if (params.solrquery !== undefined) {
+    if (params.solrquery && params.solrquery !== '_text_:*') {
+      searchParams.set('solrquery', params.solrquery);
+    } else {
+      searchParams.delete('solrquery');
+    }
+  }
+
+  if (params.sort !== undefined) {
+    if (params.sort) {
+      searchParams.set('sort', params.sort);
+    } else {
+      searchParams.delete('sort');
+    }
+  }
+
+  if (params.start !== undefined) {
+    if (params.start > 0) {
+      searchParams.set('start', params.start.toString());
+    } else {
+      searchParams.delete('start');
+    }
+  }
+
+  if (params.limit !== undefined) {
+    if (params.limit > 0) {
+      searchParams.set('limit', params.limit.toString());
+    } else {
+      searchParams.delete('limit');
+    }
+  }
+
+  if (params.nbsearch !== undefined) {
+    searchParams.set('nbsearch', params.nbsearch);
+  }
+
+  url.search = searchParams.toString();
+  window.history.replaceState({}, '', url.toString());
+}
+
+export function searchQueryToURLParams(query: SearchQuery): URLSearchParams {
+  const params: URLSearchParams = {
+    solrquery: query.queryString,
+    nbsearch: 'yes'
+  };
+
+  if (query.sortQuery) {
+    // Convert sort format: "column order" (e.g., "mtime desc")
+    const order = query.sortQuery.order === SortOrder.Ascending ? 'asc' : 'desc';
+    params.sort = `${query.sortQuery.column} ${order}`;
+  }
+
+  if (query.pageQuery) {
+    params.start = query.pageQuery.start;
+    params.limit = query.pageQuery.limit;
+  }
+
+  return params;
+}
+
+export function urlParamsToSearchQuery(params: URLSearchParams): Partial<SearchQuery> {
+  const query: Partial<SearchQuery> = {};
+
+  if (params.solrquery) {
+    query.queryString = params.solrquery;
+  }
+
+  if (params.sort) {
+    // Parse sort format: "column order" (e.g., "mtime desc")
+    const sortParts = params.sort.split(' ');
+    if (sortParts.length >= 2) {
+      const column = sortParts.slice(0, -1).join(' ');  // Handle column names with spaces
+      const order = sortParts[sortParts.length - 1];
+      query.sortQuery = {
+        column: column as IndexedColumnId,
+        order: order === 'asc' ? SortOrder.Ascending : SortOrder.Descending
+      };
+    }
+  }
+
+  if (params.start !== undefined || params.limit !== undefined) {
+    query.pageQuery = {
+      start: params.start ?? 0,
+      limit: params.limit ?? 50
+    };
+  }
+
+  return query;
+}
+
+export function hasSearchParams(): boolean {
+  const params = getSearchParamsFromURL();
+  return params.nbsearch === 'yes';
+}
+
+export function clearURLSearchParams(): void {
+  const url = new URL(window.location.href);
+  const searchParams = new URLSearchParams(url.search);
+
+  // Remove only search-related parameters
+  searchParams.delete('solrquery');
+  searchParams.delete('sort');
+  searchParams.delete('start');
+  searchParams.delete('limit');
+  searchParams.delete('size');
+  searchParams.delete('numFound');
+  searchParams.delete('error');
+  searchParams.delete('nbsearch');
+
+  url.search = searchParams.toString();
+  window.history.replaceState({}, '', url.toString());
+}

--- a/src/widgets/magic-search.tsx
+++ b/src/widgets/magic-search.tsx
@@ -523,9 +523,6 @@ export function MagicSearchWidget({
                 });
               }}
               onSearch={onSearch}
-              initialFieldsValue={
-                keyword ? getCompositeQueryFromKeyword(keyword) : undefined
-              }
             ></Query>
           )}
           queryContext={{}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5569,7 +5569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0":
+"commander@npm:^2.19.0, commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -5978,6 +5978,13 @@ __metadata:
   dependencies:
     path-type: ^4.0.0
   checksum: fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
+  languageName: node
+  linkType: hard
+
+"discontinuous-range@npm:1.0.0":
+  version: 1.0.0
+  resolution: "discontinuous-range@npm:1.0.0"
+  checksum: 8ee88d7082445b6eadc7c03bebe6dc978f96760c45e9f65d16ca66174d9e086a9e3855ee16acf65625e1a07a846a17de674f02a5964a6aebe5963662baf8b5c8
   languageName: node
   linkType: hard
 
@@ -8436,6 +8443,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"liqe@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "liqe@npm:3.8.3"
+  dependencies:
+    nearley: ^2.20.1
+    ts-error: ^1.0.6
+  checksum: 73f7b23f5f843a68bb1c0855b1cb99822ae9e92e2e8da2372ed52df5e51fa4e6e5a006730be4de7927343d96b420b280066b3e56f241144159e28d0c97fec9f8
+  languageName: node
+  linkType: hard
+
 "load-json-file@npm:^4.0.0":
   version: 4.0.0
   resolution: "load-json-file@npm:4.0.0"
@@ -8914,6 +8931,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"moo@npm:^0.5.0":
+  version: 0.5.2
+  resolution: "moo@npm:0.5.2"
+  checksum: 5a41ddf1059fd0feb674d917c4774e41c877f1ca980253be4d3aae1a37f4bc513f88815041243f36f5cf67a62fb39324f3f997cf7fb17b6cb00767c165e7c499
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
@@ -8985,6 +9009,7 @@ __metadata:
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
     jest: ^29.2.0
+    liqe: ^3.8.3
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
     rimraf: ^5.0.1
@@ -9000,6 +9025,23 @@ __metadata:
     yjs: ^13.5.0
   languageName: unknown
   linkType: soft
+
+"nearley@npm:^2.20.1":
+  version: 2.20.1
+  resolution: "nearley@npm:2.20.1"
+  dependencies:
+    commander: ^2.19.0
+    moo: ^0.5.0
+    railroad-diagrams: ^1.0.0
+    randexp: 0.4.6
+  bin:
+    nearley-railroad: bin/nearley-railroad.js
+    nearley-test: bin/nearley-test.js
+    nearley-unparse: bin/nearley-unparse.js
+    nearleyc: bin/nearleyc.js
+  checksum: 42c2c330c13c7991b48221c5df00f4352c2f8851636ae4d1f8ca3c8e193fc1b7668c78011d1cad88cca4c1c4dc087425420629c19cc286d7598ec15533aaef26
+  languageName: node
+  linkType: hard
 
 "negotiator@npm:^0.6.3":
   version: 0.6.3
@@ -9681,6 +9723,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"railroad-diagrams@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "railroad-diagrams@npm:1.0.0"
+  checksum: 9e312af352b5ed89c2118edc0c06cef2cc039681817f65266719606e4e91ff6ae5374c707cc9033fe29a82c2703edf3c63471664f97f0167c85daf6f93496319
+  languageName: node
+  linkType: hard
+
+"randexp@npm:0.4.6":
+  version: 0.4.6
+  resolution: "randexp@npm:0.4.6"
+  dependencies:
+    discontinuous-range: 1.0.0
+    ret: ~0.1.10
+  checksum: 3c0d440a3f89d6d36844aa4dd57b5cdb0cab938a41956a16da743d3a3578ab32538fc41c16cc0984b6938f2ae4cbc0216967e9829e52191f70e32690d8e3445d
+  languageName: node
+  linkType: hard
+
 "randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -9946,6 +10005,13 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 9d3b3c67aefd12cecbe5f10ca4d1f51ea190891096497c43f301b086883b426466918c3a64f1bbf1788fabb52b579d58809614006c5d0b49186702b3b8fb746a
+  languageName: node
+  linkType: hard
+
+"ret@npm:~0.1.10":
+  version: 0.1.15
+  resolution: "ret@npm:0.1.15"
+  checksum: d76a9159eb8c946586567bd934358dfc08a36367b3257f7a3d7255fdd7b56597235af23c6afa0d7f0254159e8051f93c918809962ebd6df24ca2a83dbe4d4151
   languageName: node
   linkType: hard
 
@@ -10948,6 +11014,13 @@ __metadata:
   peerDependencies:
     typescript: ">=4.2.0"
   checksum: 441cc4489d65fd515ae6b0f4eb8690057add6f3b6a63a36073753547fb6ce0c9ea0e0530220a0b282b0eec535f52c4dfc315d35f8a4c9a91c0def0707a714ca6
+  languageName: node
+  linkType: hard
+
+"ts-error@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "ts-error@npm:1.0.6"
+  checksum: 043d15c155bf3aeeb146523f24650a773a4aa607587252692640eb233f9d832b73e207c4f076c2e7bc68e9897979eec0586cf631a919f3a3c542fb981d35a5d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add URL parameter functionality to remember search conditions in Jupyter Notebook 7.

## Key Features

- URL parameters persist search state (`solrquery`, `sort`, `start`, `limit`)  
- Automatic panel opening when `nbsearch=yes` is present
- Bidirectional sync between Solr query and Search by fields tabs
- URL updates only in Notebook 7 tree view (disabled in JupyterLab to prevent SPA conflicts)

This enables users to bookmark and share search queries while maintaining compatibility across different Jupyter environments.