### PR TITLE
Add MCP server for notebook search

### DIFF
--- a/nbsearch-mcp/README.md
+++ b/nbsearch-mcp/README.md
@@ -23,8 +23,8 @@ python -m nbsearch_mcp.server --transport http --port 8000
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SOLR_BASE_URL` | Solr base URL | `http://localhost:8983` |
-| `SOLR_USERNAME` | Solr Basic Auth username | (empty) |
-| `SOLR_PASSWORD` | Solr Basic Auth password | (empty) |
+| `SOLR_BASIC_AUTH_USERNAME` | Solr Basic Auth username | (empty) |
+| `SOLR_BASIC_AUTH_PASSWORD` | Solr Basic Auth password | (empty) |
 | `S3_ENDPOINT_URL` | S3 endpoint URL | `http://localhost:9000` |
 | `S3_ACCESS_KEY` | S3 access key | (required) |
 | `S3_SECRET_KEY` | S3 secret key | (required) |

--- a/nbsearch-mcp/README.md
+++ b/nbsearch-mcp/README.md
@@ -30,6 +30,7 @@ python -m nbsearch_mcp.server --transport http --port 8000
 | `S3_SECRET_KEY` | S3 secret key | (required) |
 | `S3_REGION_NAME` | S3 region name | (none) |
 | `S3_BUCKET_NAME` | S3 bucket name | `notebooks` |
+| `NOTEBOOK_CACHE_SIZE` | Max notebooks to cache in memory | `32` |
 
 ## Tools
 
@@ -37,17 +38,17 @@ Designed for progressive drill-down from overview to detail.
 
 ### search_notebooks
 
-Search notebooks by keyword. Accepts Solr query syntax.
+Search notebooks by keyword. Accepts Solr query syntax. Returns each notebook with its table of contents.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `query` | str | (required) | Solr query (e.g. `"pandas"`, `"source__code:pandas AND owner:yazawa"`) |
 | `q_op` | str | `"AND"` | Query operator |
 | `start` | int | `0` | Pagination offset |
-| `limit` | int | `10` | Number of results |
-| `sort` | str | none | Sort field (e.g. `"mtime desc"`) |
+| `limit` | int | `20` | Number of results |
+| `sort` | str | `"mtime desc"` | Sort field |
 
-Returns: `id`, `filename`, `owner`, `server`, `mtime`, `headings`
+Returns: `id`, `filename`, `owner`, `server`, `mtime`, `cell_count`, `code_cell_count`, `toc` (heading hierarchy with code cell counts and preview)
 
 ### search_cells
 
@@ -59,33 +60,19 @@ Search at cell level.
 | `q_op` | str | `"AND"` | Query operator |
 | `start` | int | `0` | Pagination offset |
 | `limit` | int | `10` | Number of results |
-| `sort` | str | none | Sort field |
+| `sort` | str | `"estimated_mtime desc"` | Sort field |
 
 Returns: `id`, `notebook_id`, `notebook_filename`, `cell_type`, `index`, `source_preview` (first 5 lines)
 
-### get_notebook_toc
+### get_notebook
 
-Get the table of contents of a notebook.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `notebook_id` | str | Notebook ID from search results |
-
-Returns: `filename`, `cell_count`, `code_cell_count`, `toc` (heading hierarchy with code cell counts and preview)
-
-### get_notebook_section
-
-Get cells of a specific section, preserving narrative structure (markdown + code pairs).
+Get notebook content for a section identified by ref.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `notebook_id` | str | Notebook ID |
-| `heading` | str | Heading text (substring match) |
-| `cell_index` | int | Or specify by cell index |
+| `ref` | str | Section ref from search_notebooks TOC (e.g. `"s0"`, `"s3"`) |
 
-Either `heading` or `cell_index` must be provided.
-
-Returns: Array of markdown and code cells. Code cell outputs are summarized (type and size only).
+Returns: All cells from the heading to the next heading of equal or higher level. Markdown cells with full source, code cells with full source and output summary (type, size, preview).
 
 ### get_cell_output
 
@@ -101,11 +88,9 @@ Returns: `source`, `outputs` (text outputs in full, binary outputs as MIME type 
 ## Expected Usage Flow
 
 ```
-search_notebooks / search_cells   -- Search (lightweight overview)
+search_notebooks / search_cells   -- Search (with TOC)
         ↓
-get_notebook_toc                   -- Understand overall structure
-        ↓
-get_notebook_section               -- Read section content
+get_notebook               -- Read section content
         ↓
 get_cell_output                    -- Inspect execution results
 ```

--- a/nbsearch-mcp/README.md
+++ b/nbsearch-mcp/README.md
@@ -1,0 +1,111 @@
+# nbsearch-mcp
+
+MCP server for searching and retrieving Jupyter Notebooks backed by Solr (full-text search) and S3 (notebook storage).
+
+## Setup
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```bash
+# stdio (default)
+python -m nbsearch_mcp.server
+
+# Streamable HTTP (for Open WebUI, etc.)
+python -m nbsearch_mcp.server --transport http --port 8000
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SOLR_BASE_URL` | Solr base URL | `http://localhost:8983` |
+| `SOLR_USERNAME` | Solr Basic Auth username | (empty) |
+| `SOLR_PASSWORD` | Solr Basic Auth password | (empty) |
+| `S3_ENDPOINT_URL` | S3 endpoint URL | `http://localhost:9000` |
+| `S3_ACCESS_KEY` | S3 access key | (required) |
+| `S3_SECRET_KEY` | S3 secret key | (required) |
+| `S3_REGION_NAME` | S3 region name | (none) |
+| `S3_BUCKET_NAME` | S3 bucket name | `notebooks` |
+
+## Tools
+
+Designed for progressive drill-down from overview to detail.
+
+### search_notebooks
+
+Search notebooks by keyword. Accepts Solr query syntax.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | str | (required) | Solr query (e.g. `"pandas"`, `"source__code:pandas AND owner:yazawa"`) |
+| `q_op` | str | `"AND"` | Query operator |
+| `start` | int | `0` | Pagination offset |
+| `limit` | int | `10` | Number of results |
+| `sort` | str | none | Sort field (e.g. `"mtime desc"`) |
+
+Returns: `id`, `filename`, `owner`, `server`, `mtime`, `headings`
+
+### search_cells
+
+Search at cell level.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | str | (required) | Solr query (e.g. `"cell_type:code AND source__code:pandas"`) |
+| `q_op` | str | `"AND"` | Query operator |
+| `start` | int | `0` | Pagination offset |
+| `limit` | int | `10` | Number of results |
+| `sort` | str | none | Sort field |
+
+Returns: `id`, `notebook_id`, `notebook_filename`, `cell_type`, `index`, `source_preview` (first 5 lines)
+
+### get_notebook_toc
+
+Get the table of contents of a notebook.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `notebook_id` | str | Notebook ID from search results |
+
+Returns: `filename`, `cell_count`, `code_cell_count`, `toc` (heading hierarchy with code cell counts and preview)
+
+### get_notebook_section
+
+Get cells of a specific section, preserving narrative structure (markdown + code pairs).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `notebook_id` | str | Notebook ID |
+| `heading` | str | Heading text (substring match) |
+| `cell_index` | int | Or specify by cell index |
+
+Either `heading` or `cell_index` must be provided.
+
+Returns: Array of markdown and code cells. Code cell outputs are summarized (type and size only).
+
+### get_cell_output
+
+Get full execution output of a specific cell.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `notebook_id` | str | Notebook ID |
+| `cell_index` | int | Cell index |
+
+Returns: `source`, `outputs` (text outputs in full, binary outputs as MIME type and size only)
+
+## Expected Usage Flow
+
+```
+search_notebooks / search_cells   -- Search (lightweight overview)
+        ↓
+get_notebook_toc                   -- Understand overall structure
+        ↓
+get_notebook_section               -- Read section content
+        ↓
+get_cell_output                    -- Inspect execution results
+```

--- a/nbsearch-mcp/nbsearch_mcp/__main__.py
+++ b/nbsearch-mcp/nbsearch_mcp/__main__.py
@@ -1,0 +1,3 @@
+from .server import main
+
+main()

--- a/nbsearch-mcp/nbsearch_mcp/config.py
+++ b/nbsearch-mcp/nbsearch_mcp/config.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class SolrConfig:
+    base_url: str = "http://localhost:8983"
+    username: str = ""
+    password: str = ""
+    notebook_core: str = "jupyter-notebook"
+    cell_core: str = "jupyter-cell"
+
+
+@dataclass(frozen=True)
+class S3Config:
+    endpoint_url: str = "http://localhost:9000"
+    access_key: str = ""
+    secret_key: str = ""
+    region_name: str | None = None
+    bucket_name: str = "notebooks"
+
+
+@dataclass(frozen=True)
+class Config:
+    solr: SolrConfig = field(default_factory=SolrConfig)
+    s3: S3Config = field(default_factory=S3Config)
+
+
+def load_config() -> Config:
+    return Config(
+        solr=SolrConfig(
+            base_url=os.environ.get("SOLR_BASE_URL", "http://localhost:8983"),
+            username=os.environ.get("SOLR_USERNAME", ""),
+            password=os.environ.get("SOLR_PASSWORD", ""),
+            notebook_core=os.environ.get("SOLR_NOTEBOOK_CORE", "jupyter-notebook"),
+            cell_core=os.environ.get("SOLR_CELL_CORE", "jupyter-cell"),
+        ),
+        s3=S3Config(
+            endpoint_url=os.environ.get("S3_ENDPOINT_URL", "http://localhost:9000"),
+            access_key=os.environ.get("S3_ACCESS_KEY", ""),
+            secret_key=os.environ.get("S3_SECRET_KEY", ""),
+            region_name=os.environ.get("S3_REGION_NAME") or None,
+            bucket_name=os.environ.get("S3_BUCKET_NAME", "notebooks"),
+        ),
+    )

--- a/nbsearch-mcp/nbsearch_mcp/config.py
+++ b/nbsearch-mcp/nbsearch_mcp/config.py
@@ -32,8 +32,8 @@ def load_config() -> Config:
     return Config(
         solr=SolrConfig(
             base_url=os.environ.get("SOLR_BASE_URL", "http://localhost:8983"),
-            username=os.environ.get("SOLR_USERNAME", ""),
-            password=os.environ.get("SOLR_PASSWORD", ""),
+            username=os.environ.get("SOLR_BASIC_AUTH_USERNAME", ""),
+            password=os.environ.get("SOLR_BASIC_AUTH_PASSWORD", ""),
             notebook_core=os.environ.get("SOLR_NOTEBOOK_CORE", "jupyter-notebook"),
             cell_core=os.environ.get("SOLR_CELL_CORE", "jupyter-cell"),
         ),

--- a/nbsearch-mcp/nbsearch_mcp/db.py
+++ b/nbsearch-mcp/nbsearch_mcp/db.py
@@ -9,10 +9,18 @@ import io
 import json
 from urllib.parse import urlencode, urljoin
 
+import os
+
 import aioboto3
 import httpx
+from cachetools import TTLCache
 
 from .config import Config
+
+_notebook_cache: TTLCache = TTLCache(
+    maxsize=int(os.environ.get("NOTEBOOK_CACHE_SIZE", "32")),
+    ttl=3600,
+)
 
 
 class NBSearchDB:
@@ -61,6 +69,9 @@ class NBSearchDB:
     # ---- S3 -----------------------------------------------------------
 
     async def download_notebook(self, notebook_id: str) -> dict:
+        cached = _notebook_cache.get(notebook_id)
+        if cached is not None:
+            return cached
         s3cfg = self._cfg.s3
         session = aioboto3.Session(
             aws_access_key_id=s3cfg.access_key,
@@ -71,4 +82,6 @@ class NBSearchDB:
         async with session.client("s3", endpoint_url=s3cfg.endpoint_url) as s3:
             await s3.download_fileobj(s3cfg.bucket_name, notebook_id, buf)
         buf.seek(0)
-        return json.loads(buf.read().decode("utf-8"))
+        notebook = json.loads(buf.read().decode("utf-8"))
+        _notebook_cache[notebook_id] = notebook
+        return notebook

--- a/nbsearch-mcp/nbsearch_mcp/db.py
+++ b/nbsearch-mcp/nbsearch_mcp/db.py
@@ -62,8 +62,11 @@ class NBSearchDB:
             resp = await client.get(url, auth=self._solr_auth())
             resp.raise_for_status()
             data = resp.json()
-            num_found = data["response"]["numFound"]
-            logger.info("query %s q=%s numFound=%d", core, query, num_found)
+            response = data["response"]
+            logger.info(
+                "query %s q=%s returned=%d numFound=%d",
+                core, query, len(response["docs"]), response["numFound"],
+            )
             return data
 
     async def query_notebooks(self, query: str, **kwargs) -> dict:

--- a/nbsearch-mcp/nbsearch_mcp/db.py
+++ b/nbsearch-mcp/nbsearch_mcp/db.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 from urllib.parse import urlencode, urljoin
+
+logger = logging.getLogger(__name__)
 
 import os
 
@@ -58,7 +61,10 @@ class NBSearchDB:
         async with httpx.AsyncClient() as client:
             resp = await client.get(url, auth=self._solr_auth())
             resp.raise_for_status()
-            return resp.json()
+            data = resp.json()
+            num_found = data["response"]["numFound"]
+            logger.info("query %s q=%s numFound=%d", core, query, num_found)
+            return data
 
     async def query_notebooks(self, query: str, **kwargs) -> dict:
         return await self.query(self._cfg.solr.notebook_core, query, **kwargs)

--- a/nbsearch-mcp/nbsearch_mcp/db.py
+++ b/nbsearch-mcp/nbsearch_mcp/db.py
@@ -1,0 +1,74 @@
+"""Lightweight DB layer for Solr queries and S3 downloads.
+
+Replaces Tornado's AsyncHTTPClient with httpx, keeps aioboto3 for S3.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from urllib.parse import urlencode, urljoin
+
+import aioboto3
+import httpx
+
+from .config import Config
+
+
+class NBSearchDB:
+    def __init__(self, config: Config) -> None:
+        self._cfg = config
+
+    # ---- Solr ---------------------------------------------------------
+
+    def _solr_auth(self) -> httpx.BasicAuth | None:
+        if self._cfg.solr.username or self._cfg.solr.password:
+            return httpx.BasicAuth(self._cfg.solr.username, self._cfg.solr.password)
+        return None
+
+    async def query(
+        self,
+        core: str,
+        query: str,
+        *,
+        q_op: str = "AND",
+        start: int | None = None,
+        rows: int | None = None,
+        sort: str | None = None,
+    ) -> dict:
+        params: dict[str, str | int] = {"q": query, "q.op": q_op, "wt": "json"}
+        if start is not None:
+            params["start"] = start
+        if rows is not None:
+            params["rows"] = rows
+        if sort is not None:
+            params["sort"] = sort
+        url = urljoin(
+            self._cfg.solr.base_url + "/",
+            f"solr/{core}/select?{urlencode(params)}",
+        )
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, auth=self._solr_auth())
+            resp.raise_for_status()
+            return resp.json()
+
+    async def query_notebooks(self, query: str, **kwargs) -> dict:
+        return await self.query(self._cfg.solr.notebook_core, query, **kwargs)
+
+    async def query_cells(self, query: str, **kwargs) -> dict:
+        return await self.query(self._cfg.solr.cell_core, query, **kwargs)
+
+    # ---- S3 -----------------------------------------------------------
+
+    async def download_notebook(self, notebook_id: str) -> dict:
+        s3cfg = self._cfg.s3
+        session = aioboto3.Session(
+            aws_access_key_id=s3cfg.access_key,
+            aws_secret_access_key=s3cfg.secret_key,
+            region_name=s3cfg.region_name,
+        )
+        buf = io.BytesIO()
+        async with session.client("s3", endpoint_url=s3cfg.endpoint_url) as s3:
+            await s3.download_fileobj(s3cfg.bucket_name, notebook_id, buf)
+        buf.seek(0)
+        return json.loads(buf.read().decode("utf-8"))

--- a/nbsearch-mcp/nbsearch_mcp/notebook.py
+++ b/nbsearch-mcp/nbsearch_mcp/notebook.py
@@ -35,7 +35,7 @@ def build_toc(notebook: dict) -> list[dict]:
     """Build a table-of-contents from notebook cells.
 
     Returns a list of section entries, each with:
-      heading, level, cell_index, code_cell_count, preview
+      heading (prefixed with #), cell_index (for internal use)
     """
     cells = notebook["cells"]
     sections: list[dict] = []
@@ -47,32 +47,10 @@ def build_toc(notebook: dict) -> list[dict]:
         for level, text in _extract_headings(source):
             sections.append(
                 {
-                    "heading": text,
-                    "level": level,
+                    "heading": "#" * level + " " + text,
                     "cell_index": i,
-                    "code_cell_count": 0,
-                    "preview": "",
                 }
             )
-
-    for si, sec in enumerate(sections):
-        start = sec["cell_index"]
-        end = sections[si + 1]["cell_index"] if si + 1 < len(sections) else len(cells)
-        code_count = 0
-        preview_parts: list[str] = []
-        for ci in range(start, end):
-            c = cells[ci]
-            if c["cell_type"] == "code":
-                code_count += 1
-            elif c["cell_type"] == "markdown" and ci == start:
-                src = "".join(c["source"])
-                lines = src.split("\n")
-                body_lines = [
-                    ln for ln in lines if not ln.strip().startswith("#")
-                ]
-                preview_parts.append(" ".join(body_lines).strip())
-        sec["code_cell_count"] = code_count
-        sec["preview"] = _first_words(" ".join(preview_parts))
 
     return sections
 

--- a/nbsearch-mcp/nbsearch_mcp/notebook.py
+++ b/nbsearch-mcp/nbsearch_mcp/notebook.py
@@ -1,0 +1,221 @@
+"""Notebook parsing utilities for the overview-to-detail drill-down.
+
+Extracts TOC, sections, and cell outputs from raw notebook JSON,
+following nblibram's philosophy: notebooks are computational narratives,
+code cells don't stand alone — surrounding markdown provides context.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# ---- Heading extraction -----------------------------------------------
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)", re.MULTILINE)
+
+
+def _extract_headings(source: str) -> list[tuple[int, str]]:
+    """Return [(level, text), ...] from markdown source."""
+    return [(len(m.group(1)), m.group(2).strip()) for m in _HEADING_RE.finditer(source)]
+
+
+def _first_words(text: str, n: int = 20) -> str:
+    words = text.split()
+    if len(words) <= n:
+        return text.strip()
+    return " ".join(words[:n]) + " ..."
+
+
+# ---- TOC --------------------------------------------------------------
+
+
+def build_toc(notebook: dict) -> list[dict]:
+    """Build a table-of-contents from notebook cells.
+
+    Returns a list of section entries, each with:
+      heading, level, cell_index, code_cell_count, preview
+    """
+    cells = notebook["cells"]
+    sections: list[dict] = []
+
+    for i, cell in enumerate(cells):
+        if cell["cell_type"] != "markdown":
+            continue
+        source = "".join(cell["source"])
+        for level, text in _extract_headings(source):
+            sections.append(
+                {
+                    "heading": text,
+                    "level": level,
+                    "cell_index": i,
+                    "code_cell_count": 0,
+                    "preview": "",
+                }
+            )
+
+    for si, sec in enumerate(sections):
+        start = sec["cell_index"]
+        end = sections[si + 1]["cell_index"] if si + 1 < len(sections) else len(cells)
+        code_count = 0
+        preview_parts: list[str] = []
+        for ci in range(start, end):
+            c = cells[ci]
+            if c["cell_type"] == "code":
+                code_count += 1
+            elif c["cell_type"] == "markdown" and ci == start:
+                src = "".join(c["source"])
+                lines = src.split("\n")
+                body_lines = [
+                    ln for ln in lines if not ln.strip().startswith("#")
+                ]
+                preview_parts.append(" ".join(body_lines).strip())
+        sec["code_cell_count"] = code_count
+        sec["preview"] = _first_words(" ".join(preview_parts))
+
+    return sections
+
+
+# ---- Section extraction -----------------------------------------------
+
+
+def extract_section(
+    notebook: dict,
+    *,
+    heading: str | None = None,
+    cell_index: int | None = None,
+) -> list[dict]:
+    """Extract a section's cells preserving narrative structure.
+
+    Finds the section by heading text (substring match) or cell_index,
+    then returns all cells from the heading to the next heading of
+    equal or higher level — mirroring nblibram's section command.
+    """
+    cells = notebook["cells"]
+    if not cells:
+        return []
+
+    start_idx: int | None = None
+    start_level: int | None = None
+
+    if cell_index is not None:
+        start_idx = cell_index
+        src = "".join(cells[cell_index]["source"])
+        headings = _extract_headings(src)
+        if headings:
+            start_level = headings[0][0]
+    elif heading is not None:
+        for i, cell in enumerate(cells):
+            if cell["cell_type"] != "markdown":
+                continue
+            src = "".join(cell["source"])
+            for level, text in _extract_headings(src):
+                if heading.lower() in text.lower():
+                    start_idx = i
+                    start_level = level
+                    break
+            if start_idx is not None:
+                break
+
+    if start_idx is None:
+        return []
+
+    end_idx = len(cells)
+    if start_level is not None:
+        for i in range(start_idx + 1, len(cells)):
+            c = cells[i]
+            if c["cell_type"] != "markdown":
+                continue
+            src = "".join(c["source"])
+            for level, _ in _extract_headings(src):
+                if level <= start_level:
+                    end_idx = i
+                    break
+            if end_idx != len(cells):
+                break
+
+    result: list[dict] = []
+    for i in range(start_idx, end_idx):
+        cell = cells[i]
+        entry: dict[str, Any] = {
+            "cell_index": i,
+            "cell_type": cell["cell_type"],
+            "source": "".join(cell["source"]),
+        }
+        if cell["cell_type"] == "code":
+            entry["execution_count"] = cell.get("execution_count")
+            entry["output_summary"] = _summarize_outputs(cell.get("outputs", []))
+        result.append(entry)
+
+    return result
+
+
+# ---- Output helpers ----------------------------------------------------
+
+
+def _summarize_outputs(outputs: list[dict]) -> list[dict]:
+    """Summarize cell outputs: type and size, no heavy content."""
+    summaries: list[dict] = []
+    for out in outputs:
+        out_type = out["output_type"]
+        summary: dict[str, Any] = {"output_type": out_type}
+
+        if out_type == "stream":
+            text = "".join(out["text"])
+            summary["name"] = out["name"]
+            summary["length"] = len(text)
+            summary["preview"] = _first_words(text, 30)
+        elif out_type in ("execute_result", "display_data"):
+            data = out["data"]
+            summary["mime_types"] = list(data.keys())
+            if "text/plain" in data:
+                plain = "".join(data["text/plain"])
+                summary["text_preview"] = _first_words(plain, 30)
+        elif out_type == "error":
+            summary["ename"] = out["ename"]
+            summary["evalue"] = out["evalue"]
+
+        summaries.append(summary)
+    return summaries
+
+
+def get_cell_output(notebook: dict, cell_index: int) -> dict:
+    """Get full output detail for a specific cell."""
+    cells = notebook["cells"]
+    cell = cells[cell_index]  # IndexError if out of range — fail fast
+
+    result: dict[str, Any] = {
+        "cell_index": cell_index,
+        "cell_type": cell["cell_type"],
+        "source": "".join(cell["source"]),
+        "outputs": [],
+    }
+
+    for out in cell.get("outputs", []):
+        out_type = out["output_type"]
+        entry: dict[str, Any] = {"output_type": out_type}
+
+        if out_type == "stream":
+            entry["name"] = out["name"]
+            entry["text"] = "".join(out["text"])
+        elif out_type in ("execute_result", "display_data"):
+            data = out["data"]
+            entry["mime_types"] = list(data.keys())
+            for mime in ("text/plain", "text/html", "text/markdown"):
+                if mime in data:
+                    entry[mime] = "".join(data[mime])
+            for mime, content in data.items():
+                if mime.startswith(("image/", "application/")):
+                    raw = "".join(content) if isinstance(content, list) else content
+                    entry.setdefault("binary", []).append(
+                        {"mime_type": mime, "size_bytes": len(raw)}
+                    )
+        elif out_type == "error":
+            entry["ename"] = out["ename"]
+            entry["evalue"] = out["evalue"]
+            entry["traceback"] = out["traceback"]
+
+        result["outputs"].append(entry)
+
+    return result

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -99,7 +99,7 @@ async def _notebook_summary(doc: dict, cell_query: str | None = None) -> dict:
     cells = notebook["cells"]
     toc = build_toc(notebook)
     for entry in toc:
-        entry["ref"] = _register_ref(notebook_id, entry["cell_index"])
+        entry["ref"] = _register_ref(notebook_id, entry.pop("cell_index"))
 
     matching_cells: list[dict] = []
     if cell_query and cell_query != "*:*":

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -16,6 +16,7 @@ import json
 import os
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 from .config import load_config
 from .db import NBSearchDB
@@ -302,11 +303,16 @@ def main():
     )
     parser.add_argument("--host", default="127.0.0.1", help="HTTP host (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=8000, help="HTTP port (default: 8000)")
+    parser.add_argument("--allowed-host", action="append", default=[], help="Allowed Host header values (repeatable)")
     args = parser.parse_args()
 
     if args.transport == "http":
         mcp.settings.host = args.host
         mcp.settings.port = args.port
+        if args.allowed_host:
+            mcp.settings.transport_security = TransportSecuritySettings(
+                allowed_hosts=args.allowed_host,
+            )
         mcp.run(transport="streamable-http")
     else:
         mcp.run(transport="stdio")

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -112,6 +112,7 @@ async def _notebook_summary(doc: dict, cell_query: str | None = None) -> dict:
             if len(lines) > 5:
                 preview += "\n..."
             matching_cells.append({
+                "ref": _register_ref(notebook_id, cdoc["index"]),
                 "cell_type": cdoc["cell_type"],
                 "index": cdoc["index"],
                 "source_preview": preview,
@@ -234,7 +235,7 @@ async def search_notebooks(
 
 def _pick_cell_fields(doc: dict) -> dict:
     """Return lightweight cell summary for search results."""
-    source = doc.get("source", "")
+    source = doc.get("source__code") or doc.get("source__markdown") or ""
     lines = source.split("\n") if source else []
     preview = "\n".join(lines[:5])
     if len(lines) > 5:
@@ -252,6 +253,7 @@ def _pick_cell_fields(doc: dict) -> dict:
 @mcp.tool()
 @_log_elapsed
 async def search_cells(
+    ref: str | None = None,
     text: str | None = None,
     code: str | None = None,
     markdown: str | None = None,
@@ -266,6 +268,8 @@ async def search_cells(
 ) -> str:
     """Search at cell level. All parameters are optional and combined with AND.
 
+      - ref       : ref from search_notebooks matching_cells — scopes search
+                    to cells around that position in the same notebook
       - text      : search across all cell fields
       - code      : search within code cells
       - markdown  : search within markdown cells
@@ -274,6 +278,10 @@ async def search_cells(
       - filename  : filter by notebook filename
       - date_from : modified since (YYYY-MM-DD)
       - date_to   : modified until (YYYY-MM-DD)
+
+    When ref is provided, returns cells from the same notebook near that
+    position (limit cells centered around the ref). Other parameters can
+    be combined to further filter.
 
     Results are sorted by estimated modification time (newest first) by default.
     Returns first 5 lines of source only. Use get_notebook for full content.
@@ -287,11 +295,18 @@ async def search_cells(
     parts: list[str] = []
     if base != "*:*":
         parts.append(base)
+    if ref:
+        notebook_id, cell_index = _section_refs[ref]  # KeyError if expired
+        parts.append(f'notebook_id:"{notebook_id}"')
+        half = limit // 2
+        idx_from = max(0, cell_index - half)
+        idx_to = cell_index + half
+        parts.append(f"index:[{idx_from} TO {idx_to}]")
     if cell_type:
         parts.append(f"cell_type:{cell_type}")
     query = " AND ".join(parts) if parts else "*:*"
     result = await _db.query_cells(
-        query, start=start, rows=limit, sort=sort,
+        query, start=start, rows=limit, sort="index asc" if ref else sort,
     )
     response = result["response"]
     cells = [_pick_cell_fields(d) for d in response["docs"]]

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -237,6 +237,7 @@ async def search_notebooks(
     return json.dumps(
         {
             "notebooks": notebooks,
+            "returned": len(notebooks),
             "numFound": response["numFound"],
             "start": start,
         },
@@ -310,9 +311,11 @@ async def search_cells(
         query, start=start, rows=limit, sort=sort,
     )
     response = result["response"]
+    cells = [_pick_cell_fields(d) for d in response["docs"]]
     return json.dumps(
         {
-            "cells": [_pick_cell_fields(d) for d in response["docs"]],
+            "cells": cells,
+            "returned": len(cells),
             "numFound": response["numFound"],
             "start": start,
         },

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -49,42 +49,19 @@ This server searches and retrieves Jupyter Notebooks stored in Solr and S3.
 ## Search parameters
 
 search_notebooks and search_cells accept structured parameters (all optional,
-combined with AND):
+combined with AND). All text parameters use token-split search (words are
+matched independently).
 
-  phrase    — phrase search across all fields (code, markdown, outputs)
-  code      — phrase search within code cells
-  markdown  — phrase search within markdown cells
+  text      — search across all fields (code, markdown, outputs)
+  code      — search within code cells
+  markdown  — search within markdown cells
   owner     — filter by notebook owner
   filename  — filter by notebook filename
   date_from — modified since (YYYY-MM-DD)
   date_to   — modified until (YYYY-MM-DD)
-  freetext  — raw Solr query for advanced use (combined via AND with above)
 
 search_cells additionally accepts:
   cell_type — "code" or "markdown"
-
-### freetext (advanced)
-
-The freetext parameter accepts raw Solr query syntax for cases not covered
-by structured parameters. Available Solr fields:
-
-  Notebook: source__markdown__heading_1 (also _2 through _6),
-    source__markdown__hashtags, source__markdown__url,
-    outputs__stdout, outputs__stderr,
-    lc_notebook_meme__current, lc_cell_memes
-  Cell: lc_cell_meme__current, lc_cell_meme__previous, lc_cell_meme__next,
-    execution_count
-
-### MEME (lineage tracking, use via freetext)
-
-Each notebook and cell has a MEME — a UUID assigned at creation that persists
-through copies. When copied to a different environment, branch suffixes are
-appended (e.g. 437c8d0a-...-1-branch1). The base UUID matches all copies.
-
-  freetext="lc_cell_memes:437c8d0a-0862-11e7-8c9a-0242ac110002"
-    → find notebooks containing a specific cell
-  freetext="lc_cell_meme__current:437c8d0a-0862-11e7-8c9a-0242ac110002"
-    → find all copies of a cell across notebooks
 
 ## Usage flow
 
@@ -173,23 +150,22 @@ _CELL_FIELDS = {
 def _build_query(
     *,
     fields: dict[str, str],
-    phrase: str | None = None,
+    text: str | None = None,
     code: str | None = None,
     markdown: str | None = None,
     owner: str | None = None,
     filename: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
-    freetext: str | None = None,
 ) -> str:
     """Build a Solr query from structured parameters."""
     parts: list[str] = []
-    if phrase:
-        parts.append(f'"{phrase}"')
+    if text:
+        parts.append(text)
     if code:
-        parts.append(f'source__code:"{code}"')
+        parts.append(f"source__code:({code})")
     if markdown:
-        parts.append(f'source__markdown:"{markdown}"')
+        parts.append(f"source__markdown:({markdown})")
     if owner:
         parts.append(f"{fields['owner']}:{owner}")
     if filename:
@@ -198,39 +174,32 @@ def _build_query(
         fr = f"{date_from}T00:00:00Z" if date_from else "*"
         to = f"{date_to}T23:59:59Z" if date_to else "*"
         parts.append(f"{fields['mtime']}:[{fr} TO {to}]")
-    if freetext:
-        parts.append(freetext)
     return " AND ".join(parts) if parts else "*:*"
 
 
 @mcp.tool()
 @_log_elapsed
 async def search_notebooks(
-    phrase: str | None = None,
+    text: str | None = None,
     code: str | None = None,
     markdown: str | None = None,
     owner: str | None = None,
     filename: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
-    freetext: str | None = None,
     start: int = 0,
     limit: int = 10,
     sort: str = "mtime desc",
 ) -> str:
     """Search notebooks. All parameters are optional and combined with AND.
 
-    Structured parameters (phrase search):
-      - phrase    : phrase search across all fields (code, markdown, outputs)
-      - code      : phrase search within code cells
-      - markdown  : phrase search within markdown cells
-      - owner     : filter by notebook owner (token search, handles name variants)
+      - text      : search across all fields (code, markdown, outputs)
+      - code      : search within code cells
+      - markdown  : search within markdown cells
+      - owner     : filter by notebook owner
       - filename  : filter by notebook filename
       - date_from : modified since (YYYY-MM-DD)
       - date_to   : modified until (YYYY-MM-DD)
-
-    Free-text parameter (raw Solr query, token-split search):
-      - freetext  : raw Solr query, combined with other parameters via AND
 
     Results are sorted by modification time (newest first) by default.
     Returns each notebook with its table of contents (heading hierarchy,
@@ -238,14 +207,14 @@ async def search_notebooks(
     """
     query = _build_query(
         fields=_NOTEBOOK_FIELDS,
-        phrase=phrase, code=code, markdown=markdown,
+        text=text, code=code, markdown=markdown,
         owner=owner, filename=filename,
-        date_from=date_from, date_to=date_to, freetext=freetext,
+        date_from=date_from, date_to=date_to,
     )
     cell_query = _build_query(
         fields=_CELL_FIELDS,
-        phrase=phrase, code=code, markdown=markdown,
-        date_from=date_from, date_to=date_to, freetext=freetext,
+        text=text, code=code, markdown=markdown,
+        date_from=date_from, date_to=date_to,
     )
     result = await _db.query_notebooks(
         query, start=start, rows=limit, sort=sort,
@@ -283,7 +252,7 @@ def _pick_cell_fields(doc: dict) -> dict:
 @mcp.tool()
 @_log_elapsed
 async def search_cells(
-    phrase: str | None = None,
+    text: str | None = None,
     code: str | None = None,
     markdown: str | None = None,
     cell_type: str | None = None,
@@ -291,34 +260,29 @@ async def search_cells(
     filename: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
-    freetext: str | None = None,
     start: int = 0,
     limit: int = 10,
     sort: str = "estimated_mtime desc",
 ) -> str:
     """Search at cell level. All parameters are optional and combined with AND.
 
-    Structured parameters (phrase search):
-      - phrase    : phrase search across all cell fields
-      - code      : phrase search within code cells
-      - markdown  : phrase search within markdown cells
+      - text      : search across all cell fields
+      - code      : search within code cells
+      - markdown  : search within markdown cells
       - cell_type : "code" or "markdown"
-      - owner     : filter by notebook owner (token search)
+      - owner     : filter by notebook owner
       - filename  : filter by notebook filename
       - date_from : modified since (YYYY-MM-DD)
       - date_to   : modified until (YYYY-MM-DD)
-
-    Free-text parameter (raw Solr query, token-split search):
-      - freetext  : raw Solr query, combined with other parameters via AND
 
     Results are sorted by estimated modification time (newest first) by default.
     Returns first 5 lines of source only. Use get_notebook for full content.
     """
     base = _build_query(
         fields=_CELL_FIELDS,
-        phrase=phrase, code=code, markdown=markdown,
+        text=text, code=code, markdown=markdown,
         owner=owner, filename=filename,
-        date_from=date_from, date_to=date_to, freetext=freetext,
+        date_from=date_from, date_to=date_to,
     )
     parts: list[str] = []
     if base != "*:*":

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -3,7 +3,7 @@
 Exposes Jupyter Notebook search (Solr) and retrieval (S3) as MCP tools
 with a layered overview-to-detail drill-down following nblibram's philosophy:
 
-  search → toc → section → cell output
+  search → get_notebook → get_cell_output
 
 Usage:
     python -m nbsearch_mcp.server                                  # stdio
@@ -12,9 +12,11 @@ Usage:
 
 from __future__ import annotations
 
+import itertools
 import json
 import os
 
+from cachetools import TTLCache
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
@@ -27,134 +29,214 @@ mcp = FastMCP(
     instructions="""\
 This server searches and retrieves Jupyter Notebooks stored in Solr and S3.
 
-## Query syntax
+## Search parameters
 
-Queries use Solr query syntax. A bare keyword searches the default full-text
-field (_text_), which covers filenames, cell sources, and outputs with Japanese
-tokenization. Use field:value to target specific fields.
+search_notebooks and search_cells accept structured parameters (all optional,
+combined with AND):
 
-### search_notebooks fields
+  phrase    — phrase search across all fields (code, markdown, outputs)
+  code      — phrase search within code cells
+  markdown  — phrase search within markdown cells
+  owner     — filter by notebook owner
+  filename  — filter by notebook filename
+  date_from — modified since (YYYY-MM-DD)
+  date_to   — modified until (YYYY-MM-DD)
+  freetext  — raw Solr query for advanced use (combined via AND with above)
 
-  filename           — notebook filename (exact string)
-  owner              — notebook owner
-  server             — Jupyter server URL
-  mtime / ctime      — modified/created time (date range: [2024-01-01T00:00:00Z TO *])
-  source__code       — code cell content (standard tokenizer)
-  source__markdown   — markdown cell content (Japanese tokenizer)
-  source__markdown__heading    — all headings
-  source__markdown__heading_1  — h1 headings (also _2 through _6)
-  source__markdown__hashtags   — hashtags (e.g. #pandas, #データ分析)
-  source__markdown__url        — URLs in markdown
-  outputs            — all cell outputs
-  outputs__stdout    — stdout output
-  outputs__stderr    — stderr output
-  lc_notebook_meme__current — notebook MEME ID (UUID, lineage tracking)
-  lc_cell_memes      — all cell MEME IDs in the notebook
+search_cells additionally accepts:
+  cell_type — "code" or "markdown"
 
-### search_cells fields
+### freetext (advanced)
 
-  cell_type          — "code" or "markdown"
-  notebook_filename  — parent notebook filename
-  notebook_owner     — parent notebook owner
-  notebook_mtime     — parent notebook modified time
-  source__code       — code cell source
-  source__markdown   — markdown cell source
-  source__markdown__heading_1  — h1 in cell (also _2 through _6)
-  source__markdown__hashtags   — hashtags in cell
-  outputs__stdout    — stdout
-  outputs__stderr    — stderr
-  execution_count    — cell execution count
-  estimated_mtime    — cell modification time estimate
-  lc_cell_meme__current   — cell MEME ID (UUID, lineage tracking)
-  lc_cell_meme__previous  — MEME of the preceding cell
-  lc_cell_meme__next      — MEME of the following cell
+The freetext parameter accepts raw Solr query syntax for cases not covered
+by structured parameters. Available Solr fields:
 
-### MEME (lineage tracking)
+  Notebook: source__markdown__heading_1 (also _2 through _6),
+    source__markdown__hashtags, source__markdown__url,
+    outputs__stdout, outputs__stderr,
+    lc_notebook_meme__current, lc_cell_memes
+  Cell: lc_cell_meme__current, lc_cell_meme__previous, lc_cell_meme__next,
+    execution_count
+
+### MEME (lineage tracking, use via freetext)
 
 Each notebook and cell has a MEME — a UUID assigned at creation that persists
-through copies. When a notebook is copied to a different environment, branch
-suffixes are appended (e.g. 437c8d0a-...-1-branch1), so use the base UUID
-to find all copies regardless of branching.
+through copies. When copied to a different environment, branch suffixes are
+appended (e.g. 437c8d0a-...-1-branch1). The base UUID matches all copies.
 
-  - Find all notebooks containing a specific cell:
-    search_notebooks with "lc_cell_memes:437c8d0a-0862-11e7-8c9a-0242ac110002"
-  - Find all copies/derivatives of a cell across notebooks:
-    search_cells with "lc_cell_meme__current:437c8d0a-0862-11e7-8c9a-0242ac110002"
-    (the MEME tokenizer matches the base UUID, ignoring branch suffixes)
-  - Find cells adjacent to a known cell in their original notebook:
-    search_cells with "lc_cell_meme__previous:<meme>" or "lc_cell_meme__next:<meme>"
-
-### Examples
-
-  "pandas"                                      — full-text search
-  "source__code:pandas AND owner:yazawa"        — code containing pandas by yazawa
-  "source__markdown__heading_1:設定"             — notebooks with h1 heading matching 設定
-  "source__markdown__hashtags:#データ分析"       — notebooks tagged #データ分析
-  "mtime:[2024-01-01T00:00:00Z TO *]"           — modified since 2024
-  "cell_type:code AND outputs__stderr:Error"    — code cells with errors
+  freetext="lc_cell_memes:437c8d0a-0862-11e7-8c9a-0242ac110002"
+    → find notebooks containing a specific cell
+  freetext="lc_cell_meme__current:437c8d0a-0862-11e7-8c9a-0242ac110002"
+    → find all copies of a cell across notebooks
 
 ## Usage flow
 
-Use tools in this order — overview first, then drill down:
+1. search_notebooks / search_cells — find notebooks or cells.
+   search_notebooks returns each notebook with its table of contents.
+   Each TOC entry has a "ref" (e.g. "s0", "s3").
+2. get_notebook(ref="s3") — read section content using the ref from step 1.
+3. get_cell_output — inspect execution output of a specific cell.
 
-1. search_notebooks / search_cells — find notebooks or cells by keyword.
-2. get_notebook_toc — get the table of contents for a notebook.
-3. get_notebook_section — get the full content of a section.
-4. get_cell_output — get detailed execution output of a specific cell.
-
-Always start broad (search/toc) before requesting full content (section/output).
+Always start with search before requesting full content.
 """,
 )
 
 _config = load_config()
 _db = NBSearchDB(_config)
 
+# ref -> (notebook_id, cell_index) mapping, TTL 1 hour
+_section_refs: TTLCache = TTLCache(maxsize=4096, ttl=3600)
+_ref_counter = itertools.count()
+
+
+def _register_ref(notebook_id: str, cell_index: int) -> str:
+    ref = f"s{next(_ref_counter)}"
+    _section_refs[ref] = (notebook_id, cell_index)
+    return ref
+
 
 # ---- Layer 0: Search (entry point) -----------------------------------
 
 
-def _pick_notebook_fields(doc: dict) -> dict:
-    """Return only the fields useful for an overview."""
+async def _notebook_summary(doc: dict, cell_query: str | None = None) -> dict:
+    """Build a notebook summary with TOC and matching cells."""
+    notebook_id = doc["id"]
+    notebook = await _db.download_notebook(notebook_id)
+    cells = notebook["cells"]
+    toc = build_toc(notebook)
+    for entry in toc:
+        entry["ref"] = _register_ref(notebook_id, entry["cell_index"])
+
+    matching_cells: list[dict] = []
+    if cell_query and cell_query != "*:*":
+        q = f'notebook_id:"{notebook_id}" AND {cell_query}'
+        result = await _db.query_cells(q, rows=3, sort="estimated_mtime desc")
+        for cdoc in result["response"]["docs"]:
+            source = cdoc.get("source__code") or cdoc.get("source__markdown") or ""
+            lines = source.split("\n") if source else []
+            preview = "\n".join(lines[:5])
+            if len(lines) > 5:
+                preview += "\n..."
+            matching_cells.append({
+                "cell_type": cdoc["cell_type"],
+                "index": cdoc["index"],
+                "source_preview": preview,
+            })
+
     return {
-        "id": doc["id"],
         "filename": doc["filename"],
         "owner": doc.get("owner"),
         "server": doc.get("server"),
         "mtime": doc.get("mtime"),
-        "headings": doc.get("source__markdown__heading", ""),
+        "ctime": doc.get("ctime"),
+        "atime": doc.get("atime"),
+        "lc_notebook_meme__current": doc.get("lc_notebook_meme__current"),
+        "operation_note": doc.get("source__markdown__operation_note"),
+        "about": doc.get("source__markdown__about"),
+        "cell_count": len(cells),
+        "code_cell_count": sum(1 for c in cells if c["cell_type"] == "code"),
+        "toc": toc,
+        "matching_cells": matching_cells,
     }
+
+
+_NOTEBOOK_FIELDS = {
+    "owner": "owner",
+    "filename": "filename",
+    "mtime": "mtime",
+}
+
+_CELL_FIELDS = {
+    "owner": "notebook_owner",
+    "filename": "notebook_filename",
+    "mtime": "estimated_mtime",
+}
+
+
+def _build_query(
+    *,
+    fields: dict[str, str],
+    phrase: str | None = None,
+    code: str | None = None,
+    markdown: str | None = None,
+    owner: str | None = None,
+    filename: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    freetext: str | None = None,
+) -> str:
+    """Build a Solr query from structured parameters."""
+    parts: list[str] = []
+    if phrase:
+        parts.append(f'"{phrase}"')
+    if code:
+        parts.append(f'source__code:"{code}"')
+    if markdown:
+        parts.append(f'source__markdown:"{markdown}"')
+    if owner:
+        parts.append(f"{fields['owner']}:{owner}")
+    if filename:
+        parts.append(f'{fields["filename"]}:"{filename}"')
+    if date_from or date_to:
+        fr = f"{date_from}T00:00:00Z" if date_from else "*"
+        to = f"{date_to}T23:59:59Z" if date_to else "*"
+        parts.append(f"{fields['mtime']}:[{fr} TO {to}]")
+    if freetext:
+        parts.append(freetext)
+    return " AND ".join(parts) if parts else "*:*"
 
 
 @mcp.tool()
 async def search_notebooks(
-    query: str,
-    q_op: str = "AND",
+    phrase: str | None = None,
+    code: str | None = None,
+    markdown: str | None = None,
+    owner: str | None = None,
+    filename: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    freetext: str | None = None,
     start: int = 0,
-    limit: int = 10,
+    limit: int = 20,
     sort: str = "mtime desc",
 ) -> str:
-    """Search notebooks by keyword. Accepts Solr query syntax.
+    """Search notebooks. All parameters are optional and combined with AND.
 
-    Examples:
-      - "pandas"                                           : full-text search
-      - "source__code:pandas"                              : search within code cells
-      - "owner:yazawa"                                     : filter by owner
-      - "mtime:[2025-01-01T00:00:00Z TO *]"               : modified since 2025
-      - "mtime:[2025-04-01T00:00:00Z TO 2025-04-30T23:59:59Z]" : modified in April 2025
-      - "source__code:pandas AND mtime:[2025-01-01T00:00:00Z TO *]" : combine conditions
+    Structured parameters (phrase search):
+      - phrase    : phrase search across all fields (code, markdown, outputs)
+      - code      : phrase search within code cells
+      - markdown  : phrase search within markdown cells
+      - owner     : filter by notebook owner (token search, handles name variants)
+      - filename  : filter by notebook filename
+      - date_from : modified since (YYYY-MM-DD)
+      - date_to   : modified until (YYYY-MM-DD)
 
-    Date fields: mtime (modified), ctime (created). Format: YYYY-MM-DDThh:mm:ssZ
+    Free-text parameter (raw Solr query, token-split search):
+      - freetext  : raw Solr query, combined with other parameters via AND
+
     Results are sorted by modification time (newest first) by default.
-    Returns lightweight overview only (id, filename, owner, headings).
-    Drill down via get_notebook_toc → get_notebook_section for details.
+    Returns each notebook with its table of contents (heading hierarchy,
+    code cell counts, preview). Use get_notebook to read a section.
     """
+    query = _build_query(
+        fields=_NOTEBOOK_FIELDS,
+        phrase=phrase, code=code, markdown=markdown,
+        owner=owner, filename=filename,
+        date_from=date_from, date_to=date_to, freetext=freetext,
+    )
+    cell_query = _build_query(
+        fields=_CELL_FIELDS,
+        phrase=phrase, code=code, markdown=markdown,
+        date_from=date_from, date_to=date_to, freetext=freetext,
+    )
     result = await _db.query_notebooks(
-        query, q_op=q_op, start=start, rows=limit, sort=sort,
+        query, start=start, rows=limit, sort=sort,
     )
     response = result["response"]
+    notebooks = [await _notebook_summary(d, cell_query) for d in response["docs"]]
     return json.dumps(
         {
-            "notebooks": [_pick_notebook_fields(d) for d in response["docs"]],
+            "notebooks": notebooks,
             "numFound": response["numFound"],
             "start": start,
         },
@@ -181,25 +263,51 @@ def _pick_cell_fields(doc: dict) -> dict:
 
 @mcp.tool()
 async def search_cells(
-    query: str,
-    q_op: str = "AND",
+    phrase: str | None = None,
+    code: str | None = None,
+    markdown: str | None = None,
+    cell_type: str | None = None,
+    owner: str | None = None,
+    filename: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    freetext: str | None = None,
     start: int = 0,
-    limit: int = 10,
+    limit: int = 20,
     sort: str = "estimated_mtime desc",
 ) -> str:
-    """Search at cell level. Can search code and markdown cells individually.
+    """Search at cell level. All parameters are optional and combined with AND.
 
-    Examples:
-      - "cell_type:code AND source__code:pandas"
-      - "source__markdown__heading_1:Setup"
-      - "cell_type:code AND estimated_mtime:[2025-01-01T00:00:00Z TO *]" : recent code cells
+    Structured parameters (phrase search):
+      - phrase    : phrase search across all cell fields
+      - code      : phrase search within code cells
+      - markdown  : phrase search within markdown cells
+      - cell_type : "code" or "markdown"
+      - owner     : filter by notebook owner (token search)
+      - filename  : filter by notebook filename
+      - date_from : modified since (YYYY-MM-DD)
+      - date_to   : modified until (YYYY-MM-DD)
 
-    Date field: estimated_mtime. Format: YYYY-MM-DDThh:mm:ssZ
+    Free-text parameter (raw Solr query, token-split search):
+      - freetext  : raw Solr query, combined with other parameters via AND
+
     Results are sorted by estimated modification time (newest first) by default.
-    Returns first 5 lines of source only. Use get_notebook_section for full content.
+    Returns first 5 lines of source only. Use get_notebook for full content.
     """
+    base = _build_query(
+        fields=_CELL_FIELDS,
+        phrase=phrase, code=code, markdown=markdown,
+        owner=owner, filename=filename,
+        date_from=date_from, date_to=date_to, freetext=freetext,
+    )
+    parts: list[str] = []
+    if base != "*:*":
+        parts.append(base)
+    if cell_type:
+        parts.append(f"cell_type:{cell_type}")
+    query = " AND ".join(parts) if parts else "*:*"
     result = await _db.query_cells(
-        query, q_op=q_op, start=start, rows=limit, sort=sort,
+        query, start=start, rows=limit, sort=sort,
     )
     response = result["response"]
     return json.dumps(
@@ -212,67 +320,27 @@ async def search_cells(
     )
 
 
-# ---- Layer 1: TOC (overview) -----------------------------------------
+# ---- Section (narrative detail) ----------------------------------------
 
 
 @mcp.tool()
-async def get_notebook_toc(notebook_id: str) -> str:
-    """Get the table of contents of a notebook.
-
-    Returns heading hierarchy, code cell count per section, and preview text.
-    Use this to understand the overall structure, then drill down into
-    specific sections via get_notebook_section.
-    """
-    notebook = await _db.download_notebook(notebook_id)
-    toc = build_toc(notebook)
-
-    filename = notebook_id.rsplit("_", 1)[-1] if "_" in notebook_id else notebook_id
-    cells = notebook["cells"]
-    cell_count = len(cells)
-    code_cell_count = sum(1 for c in cells if c["cell_type"] == "code")
-
-    return json.dumps(
-        {
-            "notebook_id": notebook_id,
-            "filename": filename,
-            "cell_count": cell_count,
-            "code_cell_count": code_cell_count,
-            "toc": toc,
-        },
-        ensure_ascii=False,
-    )
-
-
-# ---- Layer 2: Section (narrative detail) ------------------------------
-
-
-@mcp.tool()
-async def get_notebook_section(
-    notebook_id: str,
-    heading: str | None = None,
-    cell_index: int | None = None,
+async def get_notebook(
+    ref: str,
 ) -> str:
-    """Get cells of a specific section, preserving narrative structure.
+    """Get notebook content for a section identified by ref.
 
-    Specify by heading (substring match) or cell_index.
-    Returns markdown and code cells together. Code cell outputs are
-    summarized only. Use get_cell_output for full output detail.
-
-    Examples:
-      - get_notebook_section(notebook_id="...", heading="Data Preprocessing")
-      - get_notebook_section(notebook_id="...", cell_index=5)
+    Pass the ref from a search_notebooks TOC entry (e.g. "s0", "s3").
+    Returns all cells from the heading to the next heading of equal or
+    higher level: markdown cells with full source, code cells with full
+    source and output summary (type, size, preview).
+    Use get_cell_output for full execution output.
     """
-    if heading is None and cell_index is None:
-        return json.dumps({"error": "Either heading or cell_index must be provided"})
-
+    notebook_id, cell_index = _section_refs[ref]  # KeyError if expired/invalid
     notebook = await _db.download_notebook(notebook_id)
-    cells = extract_section(notebook, heading=heading, cell_index=cell_index)
-
-    if not cells:
-        return json.dumps({"error": "No matching section found"})
-
+    cells = extract_section(notebook, cell_index=cell_index)
     return json.dumps(
         {
+            "ref": ref,
             "notebook_id": notebook_id,
             "cells": cells,
         },

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -197,7 +197,7 @@ async def search_notebooks(
     date_to: str | None = None,
     freetext: str | None = None,
     start: int = 0,
-    limit: int = 20,
+    limit: int = 10,
     sort: str = "mtime desc",
 ) -> str:
     """Search notebooks. All parameters are optional and combined with AND.
@@ -274,7 +274,7 @@ async def search_cells(
     date_to: str | None = None,
     freetext: str | None = None,
     start: int = 0,
-    limit: int = 20,
+    limit: int = 10,
     sort: str = "estimated_mtime desc",
 ) -> str:
     """Search at cell level. All parameters are optional and combined with AND.

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -131,15 +131,20 @@ async def search_notebooks(
     q_op: str = "AND",
     start: int = 0,
     limit: int = 10,
-    sort: str | None = None,
+    sort: str = "mtime desc",
 ) -> str:
     """Search notebooks by keyword. Accepts Solr query syntax.
 
     Examples:
-      - "pandas"               : full-text search
-      - "source__code:pandas"  : search within code cells
-      - "owner:yazawa"         : filter by owner
+      - "pandas"                                           : full-text search
+      - "source__code:pandas"                              : search within code cells
+      - "owner:yazawa"                                     : filter by owner
+      - "mtime:[2025-01-01T00:00:00Z TO *]"               : modified since 2025
+      - "mtime:[2025-04-01T00:00:00Z TO 2025-04-30T23:59:59Z]" : modified in April 2025
+      - "source__code:pandas AND mtime:[2025-01-01T00:00:00Z TO *]" : combine conditions
 
+    Date fields: mtime (modified), ctime (created). Format: YYYY-MM-DDThh:mm:ssZ
+    Results are sorted by modification time (newest first) by default.
     Returns lightweight overview only (id, filename, owner, headings).
     Drill down via get_notebook_toc → get_notebook_section for details.
     """
@@ -180,14 +185,17 @@ async def search_cells(
     q_op: str = "AND",
     start: int = 0,
     limit: int = 10,
-    sort: str | None = None,
+    sort: str = "estimated_mtime desc",
 ) -> str:
     """Search at cell level. Can search code and markdown cells individually.
 
     Examples:
       - "cell_type:code AND source__code:pandas"
       - "source__markdown__heading_1:Setup"
+      - "cell_type:code AND estimated_mtime:[2025-01-01T00:00:00Z TO *]" : recent code cells
 
+    Date field: estimated_mtime. Format: YYYY-MM-DDThh:mm:ssZ
+    Results are sorted by estimated modification time (newest first) by default.
     Returns first 5 lines of source only. Use get_notebook_section for full content.
     """
     result = await _db.query_cells(

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -25,7 +25,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 
 from .config import load_config
 from .db import NBSearchDB
-from .notebook import build_toc, extract_section, get_cell_output as _get_cell_output
+from .notebook import build_toc
 
 logger = logging.getLogger(__name__)
 
@@ -46,32 +46,10 @@ mcp = FastMCP(
     instructions="""\
 This server searches and retrieves Jupyter Notebooks stored in Solr and S3.
 
-## Search parameters
+1. search_notebooks — find notebooks. Returns TOC and matching_cells, each with "ref".
+2. search_cells(ref="s3") — read cells using a ref from step 1. Returns full source and outputs.
 
-search_notebooks and search_cells accept structured parameters (all optional,
-combined with AND). All text parameters use token-split search (words are
-matched independently).
-
-  text      — search across all fields (code, markdown, outputs)
-  code      — search within code cells
-  markdown  — search within markdown cells
-  owner     — filter by notebook owner
-  filename  — filter by notebook filename
-  date_from — modified since (YYYY-MM-DD)
-  date_to   — modified until (YYYY-MM-DD)
-
-search_cells additionally accepts:
-  cell_type — "code" or "markdown"
-
-## Usage flow
-
-1. search_notebooks / search_cells — find notebooks or cells.
-   search_notebooks returns each notebook with its table of contents.
-   Each TOC entry has a "ref" (e.g. "s0", "s3").
-2. get_notebook(ref="s3") — read section content using the ref from step 1.
-3. get_cell_output — inspect execution output of a specific cell.
-
-Always start with search before requesting full content.
+Always start with search_notebooks.
 """,
 )
 
@@ -154,19 +132,23 @@ def _build_query(
     text: str | None = None,
     code: str | None = None,
     markdown: str | None = None,
+    exact: bool = False,
     owner: str | None = None,
     filename: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
 ) -> str:
     """Build a Solr query from structured parameters."""
+    def _q(value: str) -> str:
+        return f'"{value}"' if exact else value
+
     parts: list[str] = []
     if text:
-        parts.append(text)
+        parts.append(_q(text))
     if code:
-        parts.append(f"source__code:({code})")
+        parts.append(f"source__code:{_q(code)}")
     if markdown:
-        parts.append(f"source__markdown:({markdown})")
+        parts.append(f"source__markdown:{_q(markdown)}")
     if owner:
         parts.append(f"{fields['owner']}:{owner}")
     if filename:
@@ -181,6 +163,7 @@ def _build_query(
 @mcp.tool()
 @_log_elapsed
 async def search_notebooks(
+    exact: bool,
     text: str | None = None,
     code: str | None = None,
     markdown: str | None = None,
@@ -192,8 +175,11 @@ async def search_notebooks(
     limit: int = 10,
     sort: str = "mtime desc",
 ) -> str:
-    """Search notebooks. All parameters are optional and combined with AND.
+    """Search notebooks. Parameters are combined with AND.
 
+      - exact     : (required) if true, text/code/markdown match exact phrase
+                    (use true for hyphenated terms like "cloudop-users",
+                     use false for natural language queries)
       - text      : search across all fields (code, markdown, outputs)
       - code      : search within code cells
       - markdown  : search within markdown cells
@@ -203,18 +189,17 @@ async def search_notebooks(
       - date_to   : modified until (YYYY-MM-DD)
 
     Results are sorted by modification time (newest first) by default.
-    Returns each notebook with its table of contents (heading hierarchy,
-    code cell counts, preview). Use get_notebook to read a section.
+    Returns each notebook with its table of contents and matching cells.
     """
     query = _build_query(
         fields=_NOTEBOOK_FIELDS,
-        text=text, code=code, markdown=markdown,
+        text=text, code=code, markdown=markdown, exact=exact,
         owner=owner, filename=filename,
         date_from=date_from, date_to=date_to,
     )
     cell_query = _build_query(
         fields=_CELL_FIELDS,
-        text=text, code=code, markdown=markdown,
+        text=text, code=code, markdown=markdown, exact=exact,
         date_from=date_from, date_to=date_to,
     )
     result = await _db.query_notebooks(
@@ -233,26 +218,27 @@ async def search_notebooks(
     )
 
 
-def _pick_cell_fields(doc: dict) -> dict:
-    """Return lightweight cell summary for search results."""
-    source = doc.get("source__code") or doc.get("source__markdown") or ""
-    lines = source.split("\n") if source else []
-    preview = "\n".join(lines[:5])
-    if len(lines) > 5:
-        preview += "\n..."
-    return {
-        "id": doc["id"],
+def _cell_detail(doc: dict) -> dict:
+    """Extract full cell content from a Solr cell document."""
+    result = {
         "notebook_id": doc["notebook_id"],
         "notebook_filename": doc["notebook_filename"],
         "cell_type": doc["cell_type"],
         "index": doc["index"],
-        "source_preview": preview,
+        "source": doc.get("source__code") or doc.get("source__markdown") or "",
     }
+    # Include outputs if present
+    for key in ("outputs__stdout", "outputs__stderr", "outputs__result_plain"):
+        val = doc.get(key)
+        if val:
+            result[key] = val
+    return result
 
 
 @mcp.tool()
 @_log_elapsed
 async def search_cells(
+    exact: bool,
     ref: str | None = None,
     text: str | None = None,
     code: str | None = None,
@@ -263,13 +249,16 @@ async def search_cells(
     date_from: str | None = None,
     date_to: str | None = None,
     start: int = 0,
-    limit: int = 10,
+    limit: int = 5,
     sort: str = "estimated_mtime desc",
 ) -> str:
-    """Search at cell level. All parameters are optional and combined with AND.
+    """Search cells and return full content. Parameters are combined with AND.
 
-      - ref       : ref from search_notebooks matching_cells — scopes search
-                    to cells around that position in the same notebook
+      - exact     : (required) if true, text/code/markdown match exact phrase
+                    (use true for hyphenated terms like "cloudop-users",
+                     use false for natural language queries)
+      - ref       : ref from search_notebooks TOC or matching_cells — scopes to
+                    cells around that position in the same notebook
       - text      : search across all cell fields
       - code      : search within code cells
       - markdown  : search within markdown cells
@@ -279,16 +268,11 @@ async def search_cells(
       - date_from : modified since (YYYY-MM-DD)
       - date_to   : modified until (YYYY-MM-DD)
 
-    When ref is provided, returns cells from the same notebook near that
-    position (limit cells centered around the ref). Other parameters can
-    be combined to further filter.
-
-    Results are sorted by estimated modification time (newest first) by default.
-    Returns first 5 lines of source only. Use get_notebook for full content.
+    Returns full source and outputs (stdout, stderr, result) for each cell.
     """
     base = _build_query(
         fields=_CELL_FIELDS,
-        text=text, code=code, markdown=markdown,
+        text=text, code=code, markdown=markdown, exact=exact,
         owner=owner, filename=filename,
         date_from=date_from, date_to=date_to,
     )
@@ -309,7 +293,7 @@ async def search_cells(
         query, start=start, rows=limit, sort="index asc" if ref else sort,
     )
     response = result["response"]
-    cells = [_pick_cell_fields(d) for d in response["docs"]]
+    cells = [_cell_detail(d) for d in response["docs"]]
     return json.dumps(
         {
             "cells": cells,
@@ -319,54 +303,6 @@ async def search_cells(
         },
         ensure_ascii=False,
     )
-
-
-# ---- Section (narrative detail) ----------------------------------------
-
-
-@mcp.tool()
-@_log_elapsed
-async def get_notebook(
-    ref: str,
-) -> str:
-    """Get notebook content for a section identified by ref.
-
-    Pass the ref from a search_notebooks TOC entry (e.g. "s0", "s3").
-    Returns all cells from the heading to the next heading of equal or
-    higher level: markdown cells with full source, code cells with full
-    source and output summary (type, size, preview).
-    Use get_cell_output for full execution output.
-    """
-    notebook_id, cell_index = _section_refs[ref]  # KeyError if expired/invalid
-    notebook = await _db.download_notebook(notebook_id)
-    cells = extract_section(notebook, cell_index=cell_index)
-    return json.dumps(
-        {
-            "ref": ref,
-            "notebook_id": notebook_id,
-            "cells": cells,
-        },
-        ensure_ascii=False,
-    )
-
-
-# ---- Layer 3: Cell output (deepest detail) ---------------------------
-
-
-@mcp.tool()
-@_log_elapsed
-async def get_cell_output(
-    notebook_id: str,
-    cell_index: int,
-) -> str:
-    """Get full execution output of a specific cell.
-
-    Returns stdout/stderr, execution results, and error tracebacks as text.
-    Binary outputs (images, etc.) are reported as MIME type and size only.
-    """
-    notebook = await _db.download_notebook(notebook_id)
-    result = _get_cell_output(notebook, cell_index)
-    return json.dumps(result, ensure_ascii=False)
 
 
 # ---- Entry point ------------------------------------------------------

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -12,9 +12,12 @@ Usage:
 
 from __future__ import annotations
 
+import functools
 import itertools
 import json
+import logging
 import os
+import time
 
 from cachetools import TTLCache
 from mcp.server.fastmcp import FastMCP
@@ -23,6 +26,20 @@ from mcp.server.transport_security import TransportSecuritySettings
 from .config import load_config
 from .db import NBSearchDB
 from .notebook import build_toc, extract_section, get_cell_output as _get_cell_output
+
+logger = logging.getLogger(__name__)
+
+
+def _log_elapsed(fn):
+    @functools.wraps(fn)
+    async def wrapper(*args, **kwargs):
+        t0 = time.monotonic()
+        result = await fn(*args, **kwargs)
+        elapsed = time.monotonic() - t0
+        logger.info("%s completed in %.2fs", fn.__name__, elapsed)
+        return result
+    return wrapper
+
 
 mcp = FastMCP(
     "nbsearch",
@@ -187,6 +204,7 @@ def _build_query(
 
 
 @mcp.tool()
+@_log_elapsed
 async def search_notebooks(
     phrase: str | None = None,
     code: str | None = None,
@@ -263,6 +281,7 @@ def _pick_cell_fields(doc: dict) -> dict:
 
 
 @mcp.tool()
+@_log_elapsed
 async def search_cells(
     phrase: str | None = None,
     code: str | None = None,
@@ -327,6 +346,7 @@ async def search_cells(
 
 
 @mcp.tool()
+@_log_elapsed
 async def get_notebook(
     ref: str,
 ) -> str:
@@ -355,6 +375,7 @@ async def get_notebook(
 
 
 @mcp.tool()
+@_log_elapsed
 async def get_cell_output(
     notebook_id: str,
     cell_index: int,

--- a/nbsearch-mcp/nbsearch_mcp/server.py
+++ b/nbsearch-mcp/nbsearch_mcp/server.py
@@ -1,0 +1,316 @@
+"""nbsearch MCP server.
+
+Exposes Jupyter Notebook search (Solr) and retrieval (S3) as MCP tools
+with a layered overview-to-detail drill-down following nblibram's philosophy:
+
+  search → toc → section → cell output
+
+Usage:
+    python -m nbsearch_mcp.server                                  # stdio
+    python -m nbsearch_mcp.server --transport http --port 8000     # Streamable HTTP
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+from .config import load_config
+from .db import NBSearchDB
+from .notebook import build_toc, extract_section, get_cell_output as _get_cell_output
+
+mcp = FastMCP(
+    "nbsearch",
+    instructions="""\
+This server searches and retrieves Jupyter Notebooks stored in Solr and S3.
+
+## Query syntax
+
+Queries use Solr query syntax. A bare keyword searches the default full-text
+field (_text_), which covers filenames, cell sources, and outputs with Japanese
+tokenization. Use field:value to target specific fields.
+
+### search_notebooks fields
+
+  filename           — notebook filename (exact string)
+  owner              — notebook owner
+  server             — Jupyter server URL
+  mtime / ctime      — modified/created time (date range: [2024-01-01T00:00:00Z TO *])
+  source__code       — code cell content (standard tokenizer)
+  source__markdown   — markdown cell content (Japanese tokenizer)
+  source__markdown__heading    — all headings
+  source__markdown__heading_1  — h1 headings (also _2 through _6)
+  source__markdown__hashtags   — hashtags (e.g. #pandas, #データ分析)
+  source__markdown__url        — URLs in markdown
+  outputs            — all cell outputs
+  outputs__stdout    — stdout output
+  outputs__stderr    — stderr output
+  lc_notebook_meme__current — notebook MEME ID (UUID, lineage tracking)
+  lc_cell_memes      — all cell MEME IDs in the notebook
+
+### search_cells fields
+
+  cell_type          — "code" or "markdown"
+  notebook_filename  — parent notebook filename
+  notebook_owner     — parent notebook owner
+  notebook_mtime     — parent notebook modified time
+  source__code       — code cell source
+  source__markdown   — markdown cell source
+  source__markdown__heading_1  — h1 in cell (also _2 through _6)
+  source__markdown__hashtags   — hashtags in cell
+  outputs__stdout    — stdout
+  outputs__stderr    — stderr
+  execution_count    — cell execution count
+  estimated_mtime    — cell modification time estimate
+  lc_cell_meme__current   — cell MEME ID (UUID, lineage tracking)
+  lc_cell_meme__previous  — MEME of the preceding cell
+  lc_cell_meme__next      — MEME of the following cell
+
+### MEME (lineage tracking)
+
+Each notebook and cell has a MEME — a UUID assigned at creation that persists
+through copies. When a notebook is copied to a different environment, branch
+suffixes are appended (e.g. 437c8d0a-...-1-branch1), so use the base UUID
+to find all copies regardless of branching.
+
+  - Find all notebooks containing a specific cell:
+    search_notebooks with "lc_cell_memes:437c8d0a-0862-11e7-8c9a-0242ac110002"
+  - Find all copies/derivatives of a cell across notebooks:
+    search_cells with "lc_cell_meme__current:437c8d0a-0862-11e7-8c9a-0242ac110002"
+    (the MEME tokenizer matches the base UUID, ignoring branch suffixes)
+  - Find cells adjacent to a known cell in their original notebook:
+    search_cells with "lc_cell_meme__previous:<meme>" or "lc_cell_meme__next:<meme>"
+
+### Examples
+
+  "pandas"                                      — full-text search
+  "source__code:pandas AND owner:yazawa"        — code containing pandas by yazawa
+  "source__markdown__heading_1:設定"             — notebooks with h1 heading matching 設定
+  "source__markdown__hashtags:#データ分析"       — notebooks tagged #データ分析
+  "mtime:[2024-01-01T00:00:00Z TO *]"           — modified since 2024
+  "cell_type:code AND outputs__stderr:Error"    — code cells with errors
+
+## Usage flow
+
+Use tools in this order — overview first, then drill down:
+
+1. search_notebooks / search_cells — find notebooks or cells by keyword.
+2. get_notebook_toc — get the table of contents for a notebook.
+3. get_notebook_section — get the full content of a section.
+4. get_cell_output — get detailed execution output of a specific cell.
+
+Always start broad (search/toc) before requesting full content (section/output).
+""",
+)
+
+_config = load_config()
+_db = NBSearchDB(_config)
+
+
+# ---- Layer 0: Search (entry point) -----------------------------------
+
+
+def _pick_notebook_fields(doc: dict) -> dict:
+    """Return only the fields useful for an overview."""
+    return {
+        "id": doc["id"],
+        "filename": doc["filename"],
+        "owner": doc.get("owner"),
+        "server": doc.get("server"),
+        "mtime": doc.get("mtime"),
+        "headings": doc.get("source__markdown__heading", ""),
+    }
+
+
+@mcp.tool()
+async def search_notebooks(
+    query: str,
+    q_op: str = "AND",
+    start: int = 0,
+    limit: int = 10,
+    sort: str | None = None,
+) -> str:
+    """Search notebooks by keyword. Accepts Solr query syntax.
+
+    Examples:
+      - "pandas"               : full-text search
+      - "source__code:pandas"  : search within code cells
+      - "owner:yazawa"         : filter by owner
+
+    Returns lightweight overview only (id, filename, owner, headings).
+    Drill down via get_notebook_toc → get_notebook_section for details.
+    """
+    result = await _db.query_notebooks(
+        query, q_op=q_op, start=start, rows=limit, sort=sort,
+    )
+    response = result["response"]
+    return json.dumps(
+        {
+            "notebooks": [_pick_notebook_fields(d) for d in response["docs"]],
+            "numFound": response["numFound"],
+            "start": start,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _pick_cell_fields(doc: dict) -> dict:
+    """Return lightweight cell summary for search results."""
+    source = doc.get("source", "")
+    lines = source.split("\n") if source else []
+    preview = "\n".join(lines[:5])
+    if len(lines) > 5:
+        preview += "\n..."
+    return {
+        "id": doc["id"],
+        "notebook_id": doc["notebook_id"],
+        "notebook_filename": doc["notebook_filename"],
+        "cell_type": doc["cell_type"],
+        "index": doc["index"],
+        "source_preview": preview,
+    }
+
+
+@mcp.tool()
+async def search_cells(
+    query: str,
+    q_op: str = "AND",
+    start: int = 0,
+    limit: int = 10,
+    sort: str | None = None,
+) -> str:
+    """Search at cell level. Can search code and markdown cells individually.
+
+    Examples:
+      - "cell_type:code AND source__code:pandas"
+      - "source__markdown__heading_1:Setup"
+
+    Returns first 5 lines of source only. Use get_notebook_section for full content.
+    """
+    result = await _db.query_cells(
+        query, q_op=q_op, start=start, rows=limit, sort=sort,
+    )
+    response = result["response"]
+    return json.dumps(
+        {
+            "cells": [_pick_cell_fields(d) for d in response["docs"]],
+            "numFound": response["numFound"],
+            "start": start,
+        },
+        ensure_ascii=False,
+    )
+
+
+# ---- Layer 1: TOC (overview) -----------------------------------------
+
+
+@mcp.tool()
+async def get_notebook_toc(notebook_id: str) -> str:
+    """Get the table of contents of a notebook.
+
+    Returns heading hierarchy, code cell count per section, and preview text.
+    Use this to understand the overall structure, then drill down into
+    specific sections via get_notebook_section.
+    """
+    notebook = await _db.download_notebook(notebook_id)
+    toc = build_toc(notebook)
+
+    filename = notebook_id.rsplit("_", 1)[-1] if "_" in notebook_id else notebook_id
+    cells = notebook["cells"]
+    cell_count = len(cells)
+    code_cell_count = sum(1 for c in cells if c["cell_type"] == "code")
+
+    return json.dumps(
+        {
+            "notebook_id": notebook_id,
+            "filename": filename,
+            "cell_count": cell_count,
+            "code_cell_count": code_cell_count,
+            "toc": toc,
+        },
+        ensure_ascii=False,
+    )
+
+
+# ---- Layer 2: Section (narrative detail) ------------------------------
+
+
+@mcp.tool()
+async def get_notebook_section(
+    notebook_id: str,
+    heading: str | None = None,
+    cell_index: int | None = None,
+) -> str:
+    """Get cells of a specific section, preserving narrative structure.
+
+    Specify by heading (substring match) or cell_index.
+    Returns markdown and code cells together. Code cell outputs are
+    summarized only. Use get_cell_output for full output detail.
+
+    Examples:
+      - get_notebook_section(notebook_id="...", heading="Data Preprocessing")
+      - get_notebook_section(notebook_id="...", cell_index=5)
+    """
+    if heading is None and cell_index is None:
+        return json.dumps({"error": "Either heading or cell_index must be provided"})
+
+    notebook = await _db.download_notebook(notebook_id)
+    cells = extract_section(notebook, heading=heading, cell_index=cell_index)
+
+    if not cells:
+        return json.dumps({"error": "No matching section found"})
+
+    return json.dumps(
+        {
+            "notebook_id": notebook_id,
+            "cells": cells,
+        },
+        ensure_ascii=False,
+    )
+
+
+# ---- Layer 3: Cell output (deepest detail) ---------------------------
+
+
+@mcp.tool()
+async def get_cell_output(
+    notebook_id: str,
+    cell_index: int,
+) -> str:
+    """Get full execution output of a specific cell.
+
+    Returns stdout/stderr, execution results, and error tracebacks as text.
+    Binary outputs (images, etc.) are reported as MIME type and size only.
+    """
+    notebook = await _db.download_notebook(notebook_id)
+    result = _get_cell_output(notebook, cell_index)
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ---- Entry point ------------------------------------------------------
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="nbsearch MCP server")
+    parser.add_argument(
+        "--transport", choices=["stdio", "http"], default="stdio",
+        help="Transport type (default: stdio)",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="HTTP host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8000, help="HTTP port (default: 8000)")
+    args = parser.parse_args()
+
+    if args.transport == "http":
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/nbsearch-mcp/pyproject.toml
+++ b/nbsearch-mcp/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "mcp[cli]>=1.0.0",
     "httpx>=0.27",
     "aioboto3>=13.0",
+    "cachetools>=5.0",
 ]
 
 [build-system]

--- a/nbsearch-mcp/pyproject.toml
+++ b/nbsearch-mcp/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "nbsearch-mcp"
+version = "0.1.0"
+description = "MCP server for searching and retrieving Jupyter Notebooks via Solr and S3"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp[cli]>=1.0.0",
+    "httpx>=0.27",
+    "aioboto3>=13.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- Add `nbsearch-mcp` package: an MCP server that exposes notebook search (Solr) and retrieval (S3) as tools for LLM agents
- Two tools: `search_notebooks` (structured query with TOC and matching cells) and `search_cells` (full cell content with ref-based navigation)
- Supports stdio and Streamable HTTP transports (for Open WebUI integration)
- Section ref system (`s0`, `s1`, ...) for easy drill-down without exposing long internal IDs
- S3 download cache (TTLCache) for notebook TOC generation

## Design
- Structured query parameters (`text`, `code`, `markdown`, `owner`, `filename`, `date_from`, `date_to`, `exact`) instead of raw Solr queries, optimized for small LLMs
- Progressive drill-down: `search_notebooks` → `search_cells(ref=...)`
- Follows nblibram's philosophy: notebooks are computational narratives